### PR TITLE
ci: fix discovery of project version from git tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,18 @@ jobs:
        ref: ${{ github.event.pull_request.head.sha }}
        fetch-depth: 0
 
+    - name: fetch annotated tag
+      if: matrix.create_release && startswith(github.ref, 'refs/tags')
+      run: |
+        # Ensure git-describe works on a tag.
+        #  (checkout@v2 action may have left current tag as
+        #   lightweight instead of annotated. See
+        #   https://github.com/actions/checkout/issues/290)
+        #
+        echo github.ref == ${{ github.ref }} ;
+        git fetch -f origin ${{ github.ref }}:${{ github.ref }} ;
+        echo git describe now reports $(git describe --always)
+
     - name: get tag name
       id: tag
       run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}


### PR DESCRIPTION
Problem: The github checkout action may leave tags as lightweight,
but this causes git-describe to fail to find the tag, and therefore
an incorrect version of the project is discovered by configure.

Add the 'fetch annotated tag' step from flux-core to ensure
git-describe works and the 'make dist' tarball is correctly named.

This is required for the automatic deployment of tarballs from github actions.