### PR TITLE
ci: update fedora35 to fedora38 and other small fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,8 @@ jobs:
           image: "el8"
           env:
             chain_lint: t
-        - name: "fedora35"
-          image: "fedora35"
+        - name: "fedora38"
+          image: "fedora38"
           env: {}
       fail-fast: false
     name: ${{ matrix.name }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,12 +73,16 @@ jobs:
 
     - name: create release
       id: create_release
-      if: success() && matrix.create_release && startswith(github.ref, 'refs/tags')
+      if: |
+        success()
+         && matrix.create_release
+         && startswith(github.ref, 'refs/tags')
+         && github.repository == 'flux-framework/flux-pam'
       uses: softprops/action-gh-release@v1
       with:
-        tag_name: ${{ steps.tag.output.name }}
-        release_name: flux-pam ${{ steps.tag.output.name }}
+        tag_name: ${{ steps.tag.output.TAG }}
+        name: flux-pam ${{ steps.tag.output.TAG }}
         prerelease: true
-        body: |
-          View [Release Notes](https://github.com/${{ github.repository }}/blob/${{ matrix.tag }}/NEWS.md) for flux-accounting ${{ matrix.tag }}
         files: flux-pam*.tar.gz
+        body: |
+          View [Release Notes](https://github.com/${{ github.repository }}/blob/${{ matrix.tag }}/NEWS.md) for flux-pam ${{ steps.tag.output.TAG }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -38,7 +38,7 @@ jobs:
     name: ${{ matrix.name }}
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
        ref: ${{ github.event.pull_request.head.sha }}
        fetch-depth: 0
@@ -47,7 +47,7 @@ jobs:
       if: matrix.create_release && startswith(github.ref, 'refs/tags')
       run: |
         # Ensure git-describe works on a tag.
-        #  (checkout@v2 action may have left current tag as
+        #  (checkout@v3 action may have left current tag as
         #   lightweight instead of annotated. See
         #   https://github.com/actions/checkout/issues/290)
         #

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: get tag name
       id: tag
-      run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
+      run: echo "TAG=${GITHUB_REF/refs\/tags\//}" >$GITHUB_OUTPUT
 
     - name: docker-run-checks
       env: ${{ matrix.env }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,9 +2,6 @@ queue_rules:
   - name: default
     conditions:
       - base=main
-      - status-success="el8"
-      - status-success="focal"
-      - status-success="fedora35"
       - label="merge-when-passing"
       - label!="work-in-progress"
       - "approved-reviews-by=@flux-framework/core"

--- a/src/test/docker/fedora38/Dockerfile
+++ b/src/test/docker/fedora38/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluxrm/flux-core:fedora35
+FROM fluxrm/flux-core:fedora38
 
 ARG USER=fluxuser
 ARG UID=1000


### PR DESCRIPTION
flux-core has dropped fedora35 in favor of fedora38, so we need to do that here as well.

Also fixed a few other things I noticed in the GitHub actions config.