### PR TITLE
remove use of deprecated commands and functions

### DIFF
--- a/src/pam/pam_flux.c
+++ b/src/pam/pam_flux.c
@@ -88,6 +88,7 @@ static int flux_check_user (uid_t uid)
                          "userid", uid,
                          "states", FLUX_JOB_STATE_RUNNING);
     if (!f || flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0) {
+        flux_future_destroy (f);
         log_msg (LOG_ERR, "flux_job_list: %m");
         goto out;
     }

--- a/src/pam/pam_flux.c
+++ b/src/pam/pam_flux.c
@@ -76,11 +76,17 @@ static int flux_check_user (uid_t uid)
         goto out;
     }
 
-    f = flux_job_list (h,
+    f = flux_rpc_pack (h,
+                       "job-list.list",
                        0,
-                       "[\"ranks\", \"state\"]",
-                       uid,
-                       FLUX_JOB_STATE_RUNNING);
+                       0,
+                       "{s:i s:[ss] s:{s:[{s:[i]} {s:[i]}]}}",
+                       "max_entries", 0,
+                       "attrs", "ranks", "state",
+                       "constraint",
+                        "and",
+                         "userid", uid,
+                         "states", FLUX_JOB_STATE_RUNNING);
     if (!f || flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0) {
         log_msg (LOG_ERR, "flux_job_list: %m");
         goto out;

--- a/t/t0001-pam_flux.t
+++ b/t/t0001-pam_flux.t
@@ -41,7 +41,7 @@ test_expect_success 'pam_flux: module denies access with no jobs running' '
 	test_must_fail pamtest -u ${USER} 
 '
 test_expect_success 'pam_flux: module allows access with a job running' '
-	jobid=$(flux mini submit --wait-event=alloc sleep 300) &&
+	jobid=$(flux submit --wait-event=alloc sleep 300) &&
 	pamtest -u ${USER}
 '
 test_expect_success 'pam_flux: module does not let any old user in' '
@@ -69,7 +69,7 @@ test_expect_success 'pam_flux: module denies access during CLEANUP' '
 	EOF
 	flux config reload &&
 	flux jobtap load perilog.so &&
-	jobid=$(flux mini submit --wait-event=epilog-start hostname) &&
+	jobid=$(flux submit --wait-event=epilog-start hostname) &&
 	test_must_fail pamtest -u ${USER} &&
 	flux jobs -o "{id.f58}: {state}" &&
 	flux event pub pam-test-done &&


### PR DESCRIPTION
This PR switches the flux PAM module away from the deprecated `flux_job_list(3)` funciton and `flux-mini(1)` command.

