### PR TITLE
NEWS.md: Add release note for v0.2.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+flux-pam version 0.2.0 - 2023-10-04
+-----------------------------------
+
+* remove use of deprecated commands and functions (#5)
+
 flux-pam version 0.1.0 - 2022-06-27
 -----------------------------------
 


### PR DESCRIPTION
Problem: There are no release notes for a flux-pam v0.2.0 tag.

Add the single release note for this version to NEWS.md.