### PR TITLE
support `allow-guest-user` option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,8 @@ jobs:
           image: "el8"
           env:
             chain_lint: t
-        - name: "fedora38"
-          image: "fedora38"
+        - name: "fedora40"
+          image: "fedora40"
           env: {}
       fail-fast: false
     name: ${{ matrix.name }}

--- a/config/ax_flux_core.m4
+++ b/config/ax_flux_core.m4
@@ -49,7 +49,7 @@ AC_DEFUN([AX_FLUX_CORE], [
   PKG_CONFIG_PATH=${prefix}/lib/pkgconfig:${PKG_CONFIG_PATH}
   export PKG_CONFIG_PATH
 
-  PKG_CHECK_MODULES([FLUX_CORE], [flux-core > 0.29.0],
+  PKG_CHECK_MODULES([FLUX_CORE], [flux-core > 0.64.0],
     [
       FLUX_PREFIX=`pkg-config --variable=prefix flux-core`
       LIBFLUX_VERSION=`pkg-config --modversion flux-core`

--- a/src/pam/pam_flux.c
+++ b/src/pam/pam_flux.c
@@ -32,9 +32,20 @@
 #include <jansson.h>
 
 #include <flux/core.h>
+#include <flux/idset.h>
 
 #define PAM_SM_ACCOUNT
 #include <security/pam_modules.h>
+
+struct options {
+    /*  If set, permit access to all users if the specified user has
+     *  a job in RUN state on this host, this is rank 0 of that job,
+     *  the job is an instance of Flux, and has access.allow-guest-user
+     *  configured.
+     *  (Allows guests to access multi-user instance jobs via ssh connector)
+     */
+    bool allow_guest_user;
+};
 
 /*
  *  Write message described by the 'format' string to syslog.
@@ -51,10 +62,139 @@ static void log_msg (int level, const char *format, ...)
     return;
 }
 
-/*  Return 1 if uid has the local rank currently allocated to an active
- *   Flux job.
+static char *uri_to_local (const char *uri)
+{
+    char *local_uri = NULL;
+    char *p;
+
+    /* Ensure this uri starts with `ssh://`
+     */
+    if (!uri || strncmp (uri, "ssh://", 6) != 0)
+        return NULL;
+
+    /* Skip to next '/' after ssh:// part
+     */
+    if (!(p = strchr (uri+6, '/')))
+        return NULL;
+
+    /* Construct local uri from remainder (path)
+     */
+    if (asprintf (&local_uri, "local:///%s", p) < 0)
+        return NULL;
+    return local_uri;
+}
+
+/* Return 1 if local instance at uri has access.allow-guest-user=true.
+ * Return 0 otherwise.
  */
-static int flux_check_user (uid_t uid)
+static int check_guest_allowed (const char *uri)
+{
+    int allowed = 0;
+    flux_t *h = NULL;
+    flux_future_t *f = NULL;
+    char *local_uri = NULL;
+
+    if (!uri)
+        goto out;
+
+    if (!(local_uri = uri_to_local (uri))) {
+        log_msg (LOG_ERR, "failed to transform %s into local uri", uri);
+        goto out;
+    }
+    if (!(h = flux_open (local_uri, 0))) {
+        log_msg (LOG_ERR, "flux_open (%s): %m", local_uri);
+        goto out;
+    }
+    if (!(f = flux_rpc (h, "config.get", NULL, FLUX_NODEID_ANY, 0))
+        || flux_rpc_get_unpack (f,
+                                "{s?{s?b}}",
+                                "access",
+                                 "allow-guest-user", &allowed) < 0) {
+        log_msg (LOG_ERR, "failed to get config: %m");
+        goto out;
+    }
+    if (!allowed)
+        log_msg (LOG_INFO, "access.allow-guest-user not enabled in child");
+out:
+    flux_close (h);
+    free (local_uri);
+    return allowed;
+}
+
+/* Loop over jobs in json array 'jobs'.
+ * - If any job owner is uid, permit.
+ * - If any job owner is allow_if_user and rank == rank 0 of the job,
+ *   permit if the job is an instance (has a uri) and acesss.allow-guest-user
+ *   is true.
+ */
+static int check_jobs_array (json_t *jobs,
+                             unsigned int rank,
+                             uid_t uid,
+                             uid_t allow_if_user)
+{
+    size_t index;
+    json_t *entry;
+
+    json_array_foreach (jobs, index, entry) {
+        const char *job_ranks;
+        const char *uri = NULL;
+        int job_uid;
+
+        if (json_unpack (entry,
+                         "{s:i s:s s?{s?{s?s}}}",
+                         "userid", &job_uid,
+                         "ranks", &job_ranks,
+                         "annotations",
+                          "user",
+                           "uri", &uri) < 0) {
+            log_msg (LOG_ERR, "failed to unpack userid, ranks for job");
+            return 0;
+        }
+        if (job_uid == uid)
+            return 1;
+        else if (job_uid == allow_if_user) {
+            struct idset *ranks;
+            if ((ranks = idset_decode (job_ranks))) {
+                int allowed = 0;
+                /* Only if this rank is rank 0 of the job, check that
+                 * access.allow-guest-user is enabled in the job instance:
+                 */
+                if (rank == idset_first (ranks))
+                    allowed = check_guest_allowed (uri);
+                idset_destroy (ranks);
+                if (allowed)
+                    return 1;
+            }
+        }
+    }
+    return 0;
+}
+
+/* Fetch an attribute and return its value as uid_t.
+ */
+static uid_t attr_get_uid (flux_t *h, const char *name)
+{
+    const char *s;
+    char *endptr;
+    long i;
+
+    if (!(s = flux_attr_get (h, name))) {
+        log_msg (LOG_ERR, "flux_attr_get (%s): %m", name);
+        return (uid_t) -1;
+    }
+    errno = 0;
+    i = strtol (s, &endptr, 10);
+    if (errno != 0 || *endptr != '\0') {
+        log_msg (LOG_ERR, "error converting %s to uid: %m", name);
+        return (uid_t) -1;
+    }
+    return (uid_t) i;
+}
+
+
+/*  get jobs in RUN state on this node for user(s) of interest:
+ */
+static int flux_check_user (struct options *opts, uid_t uid)
 {
     int authorized = 0;
     json_t *jobs = NULL;
@@ -63,6 +203,13 @@ static int flux_check_user (uid_t uid)
     char rankstr[16];
     flux_future_t *f = NULL;
 
+    /* allow_if_user MAY be set to the instance owner to allow guest
+     * access for uid to this node in the case of a multi-user subinstance.
+     * However, initialize it to uid so it can unconditionally be used below
+     * in the RPC to job-list, which greatly simplifies code.
+     */
+    uid_t allow_if_user = uid;
+
     if (!(h = flux_open (NULL, 0))) {
         log_msg (LOG_ERR, "Unable to connect to Flux: %m");
         return 0;
@@ -70,6 +217,14 @@ static int flux_check_user (uid_t uid)
     if (flux_get_rank (h, &rank) < 0) {
         log_msg (LOG_ERR, "Failed to get current broker rank: %m");
         goto out;
+    }
+    if (opts->allow_guest_user) {
+        uid_t owner = attr_get_uid (h, "security.owner");
+        if (owner != (uid_t) -1)
+            allow_if_user = owner;
+        else
+            log_msg (LOG_ERR,
+                     "Failed to get security.owner, can't allow guest access");
     }
     if (snprintf (rankstr,
                   sizeof (rankstr),
@@ -85,12 +240,12 @@ static int flux_check_user (uid_t uid)
                        "job-list.list",
                        0,
                        0,
-                       "{s:i s:[ss] s:{s:[{s:[i]} {s:[s]} {s:[i]}]}}",
+                       "{s:i s:[sss] s:{s:[{s:[ii]} {s:[s]} {s:[i]}]}}",
                        "max_entries", 0,
-                       "attrs", "ranks", "state",
+                       "attrs", "userid", "ranks", "annotations",
                        "constraint",
                         "and",
-                         "userid", uid,
+                         "userid", uid, allow_if_user,
                          "ranks", rankstr,
                          "states", FLUX_JOB_STATE_RUN);
     if (!f || flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0) {
@@ -98,10 +253,7 @@ static int flux_check_user (uid_t uid)
         goto out;
     }
 
-    /* If there was at least one job returned, then this user is allowed
-     */
-    if (json_array_size (jobs) > 0)
-        authorized = 1;
+    authorized = check_jobs_array (jobs, rank, uid, allow_if_user);
 
 out:
     flux_future_destroy (f);
@@ -167,6 +319,23 @@ static void send_denial_msg (pam_handle_t *pamh,
     return;
 }
 
+static int parse_options (struct options *opts, int argc, const char **argv)
+{
+    for (int i = 0; i < argc; i++) {
+        if (strcmp ("allow-guest-user", argv[i]) == 0) {
+            opts->allow_guest_user = true;
+        }
+        else {
+            log_msg (LOG_ERR,
+                    "unrecognized option: %s",
+                    argv[i]);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+
 PAM_EXTERN int
 pam_sm_acct_mgmt (pam_handle_t *pamh, int flags, int argc, const char **argv)
 {
@@ -175,6 +344,7 @@ pam_sm_acct_mgmt (pam_handle_t *pamh, int flags, int argc, const char **argv)
     struct passwd *pw;
     uid_t uid;
     int auth = PAM_PERM_DENIED;
+    struct options opts = { .allow_guest_user = false };
 
     retval = pam_get_item (pamh, PAM_USER, (const void **) &user);
     if ((retval != PAM_SUCCESS) || (user == NULL) || (*user == '\0')) {
@@ -189,7 +359,10 @@ pam_sm_acct_mgmt (pam_handle_t *pamh, int flags, int argc, const char **argv)
     }
     uid = pw->pw_uid;
 
-    if (flux_check_user (uid))
+    if (parse_options (&opts, argc, argv) < 0)
+        return PAM_SYSTEM_ERR;
+
+    if (flux_check_user (&opts, uid))
         auth = PAM_SUCCESS;
 
     if (auth != PAM_SUCCESS)

--- a/src/pam/pam_flux.c
+++ b/src/pam/pam_flux.c
@@ -95,7 +95,6 @@ static int flux_check_user (uid_t uid)
                          "ranks", rankstr,
                          "states", FLUX_JOB_STATE_RUN);
     if (!f || flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0) {
-        flux_future_destroy (f);
         log_msg (LOG_ERR, "flux_job_list: %m");
         goto out;
     }

--- a/src/pam/pam_flux.c
+++ b/src/pam/pam_flux.c
@@ -35,7 +35,6 @@
 
 #define PAM_SM_ACCOUNT
 #include <security/pam_modules.h>
-#include <security/_pam_macros.h>
 
 /*
  *  Write message described by the 'format' string to syslog.
@@ -157,8 +156,13 @@ static void send_denial_msg (pam_handle_t *pamh,
         log_msg (LOG_ERR,
                  "unable to converse with app: %s",
                  pam_strerror (pamh, retval));
-    if (prsp != NULL)
-        _pam_drop_reply (prsp, 1);
+    if (prsp != NULL) {
+        /* N.B. _pam_drop_reply() deprecated in recent versions
+         * of Linux-PAM. Free reply without use of macros:
+         */
+        free (prsp[0].resp);
+        free (prsp);
+    }
 
     return;
 }

--- a/src/test/docker/fedora40/Dockerfile
+++ b/src/test/docker/fedora40/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluxrm/flux-core:fedora38
+FROM fluxrm/flux-core:fedora40
 
 ARG USER=fluxuser
 ARG UID=1000

--- a/t/t0001-pam_flux.t
+++ b/t/t0001-pam_flux.t
@@ -58,14 +58,8 @@ test_expect_success 'pam_flux: module denies access on flux_open() failure' '
 '
 test_expect_success 'pam_flux: module denies access during CLEANUP' '
 	cat <<-EOF >config/epilog.toml &&
-	#  Note: prolog only needs to be configured due to bug in
-	#   flux-core <= v0.40.0
-	[job-manager.prolog]
-	command = [ "/bin/true" ]
-
 	[job-manager.epilog]
 	command = [ "flux", "event", "sub", "-c1",  "pam-test-done" ]
-
 	EOF
 	flux config reload &&
 	flux jobtap load perilog.so &&

--- a/t/t0001-pam_flux.t
+++ b/t/t0001-pam_flux.t
@@ -62,6 +62,7 @@ test_expect_success 'pam_flux: module denies access during CLEANUP' '
 	command = [ "flux", "event", "sub", "-c1",  "pam-test-done" ]
 	EOF
 	flux config reload &&
+	test_when_finished "rm config/epilog.toml && flux config reload" &&
 	flux jobtap load perilog.so &&
 	jobid=$(flux submit --wait-event=epilog-start hostname) &&
 	test_must_fail pamtest -u ${USER} &&

--- a/t/t0001-pam_flux.t
+++ b/t/t0001-pam_flux.t
@@ -4,6 +4,7 @@ test_description='Basic plugin tests'
 
 . `dirname $0`/sharness.sh
 
+export FLUX_URI_RESOLVE_LOCAL=t
 PAM_FLUX_PATH=${FLUX_BUILD_DIR}/src/pam/.libs/pam_flux.so
 PAMTEST=${FLUX_BUILD_DIR}/t/pamtest
 
@@ -14,7 +15,7 @@ if ! test -x ${PAMTEST}; then
 fi
 
 mkdir config
-test_under_flux 1 full -o,--config-path=$(pwd)/config
+test_under_flux 2 full -o,--config-path=$(pwd)/config
 
 #  Check for libpam_wrapper.so
 LD_PRELOAD=libpam_wrapper.so ${PAMTEST} -h >ld_preload.out 2>&1
@@ -28,6 +29,15 @@ pamtest() {
 	PAM_WRAPPER=1 \
 	PAM_WRAPPER_SERVICE_DIR=$(pwd) \
 	${PAMTEST} -v -s pam-test "$@"
+}
+
+pamtest_on_rank() {
+	RANK=$1
+	shift
+	LD_PRELOAD=libpam_wrapper.so \
+	PAM_WRAPPER=1 \
+	PAM_WRAPPER_SERVICE_DIR=$(pwd) \
+	flux exec -r ${RANK} ${PAMTEST} -v -s pam-test "$@"
 }
 
 test_expect_success 'pam_flux: create pam-test PAM stack' '
@@ -69,5 +79,56 @@ test_expect_success 'pam_flux: module denies access during CLEANUP' '
 	flux jobs -o "{id.f58}: {state}" &&
 	flux event pub pam-test-done &&
 	flux job wait-event -vt 15 ${jobid} clean
+'
+test_expect_success 'add allow-guest-user to pam_flux module options' '
+	cat <<-EOF >pam-test
+	auth    required   pam_localuser.so
+	account required ${PAM_FLUX_PATH} allow-guest-user
+	EOF
+'
+test_expect_success 'pam_flux: module denies access with allow-guest-access' '
+	test_must_fail pamtest -u ${USER} 2>allow-guest.err &&
+	test_debug "cat allow-guest.err" &&
+	grep "Access denied: user ${USER}" allow-guest.err &&
+	test_must_fail pamtest -u nobody 2>allow-guest1.err &&
+	test_debug "cat allow-guest1.err" &&
+	grep "Access denied: user nobody" allow-guest1.err
+'
+test_expect_success 'pam_flux: access denied if job not an instance' '
+	id=$(flux submit -N1 --requires=rank:0 sleep inf) &&
+	test_must_fail pamtest -u nobody 2>no-uri.err &&
+	test_debug "cat no-uri.err" &&
+	grep "Access denied: user nobody" no-uri.err &&
+	flux cancel $id &&
+	flux job wait-event -vt 15 $id clean
+'
+test_expect_success 'pam_flux: but job user still given access' '
+	id=$(flux submit -N1 --requires=rank:0 sleep inf) &&
+	pamtest -u ${USER} && # but job user is still allowed
+	flux cancel $id &&
+	flux job wait-event -vt 15 $id clean
+'
+test_expect_success 'pam_flux: access denied if access.allow-guest-user=0' '
+	id=$(flux alloc --bg -N1 --requires=rank:0) &&
+	test_must_fail pamtest -u nobody 2>allow-guest2.err &&
+	test_debug "cat allow-guest2.err" &&
+	grep "Access denied: user nobody" allow-guest2.err &&
+	flux cancel $id &&
+	flux job wait-event -vt 15 $id clean
+'
+test_expect_success 'pam_flux: access allowed if access.allow-guest-user=1' '
+	id=$(flux alloc --requires=rank:0 \
+             --conf=access.allow-guest-user=true --bg -N1) &&
+	pamtest -u nobody &&
+	flux cancel $id &&
+	flux job wait-event -vt 15 $id clean
+'
+test_expect_success 'pam_flux: access denied if not rank 0 of job' '
+	id=$(flux alloc --conf=access.allow-guest-user=true --bg -N2) &&
+	test_must_fail pamtest_on_rank 1 -u nobody 2>allow-guest3.err &&
+	test_debug "cat allow-guest3.err" &&
+	grep "Access denied: user nobody" allow-guest3.err &&
+	flux cancel $id &&
+	flux job wait-event -vt 15 $id clean
 '
 test_done


### PR DESCRIPTION
This PR adds support for a new `allow-guest-user` option to the `flux_pam.so` module.

This option can be used to permit access to _any_ user to a node, not only if they have a job running on the node, but additionally if all of the following are true:

 - there is job running on the node owned by the system instance owner
 - the current node is rank 0 of that job
 - the job is an instance of Flux
 - the instance of flux has `access.allow-guest-user` set to `true`
 
 This is a necessary first step to allow user access to multi-user subinstances via `flux proxy`.