### PR TITLE
testsuite: use `flux cancel` instead of `flux job cancel`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -38,7 +38,7 @@ jobs:
     name: ${{ matrix.name }}
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
        ref: ${{ github.event.pull_request.head.sha }}
        fetch-depth: 0
@@ -47,7 +47,7 @@ jobs:
       if: matrix.create_release && startswith(github.ref, 'refs/tags')
       run: |
         # Ensure git-describe works on a tag.
-        #  (checkout@v3 action may have left current tag as
+        #  (checkout@v4 action may have left current tag as
         #   lightweight instead of annotated. See
         #   https://github.com/actions/checkout/issues/290)
         #

--- a/t/t0001-pam_flux.t
+++ b/t/t0001-pam_flux.t
@@ -58,7 +58,7 @@ test_expect_success 'pam_flux: module does not let any old user in' '
 	test_must_fail pamtest -u nobody
 '
 test_expect_success 'pam_flux: module denies access after job terminates' '
-	flux job cancel $jobid &&
+	flux cancel $jobid &&
 	flux job wait-event -vt 15 $jobid free &&
 	test_must_fail pamtest -u ${USER}
 '


### PR DESCRIPTION
Problem: `flux job cancel` has been deprecated but it is still used once in the flux-pam testsuite.

Use `flux cancel` in place of `flux job cancel` in t0001-pam_flux.t.