### PR TITLE
mergify: disable temporary PR branches

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,6 @@
 queue_rules:
   - name: default
+    batch_size: 1
     queue_conditions:
       - base=main
       - label="merge-when-passing"
@@ -18,6 +19,12 @@ queue_rules:
       - -title~=^\[*[Ww][Ii][Pp]
     update_method: rebase
     merge_method: merge
+
+# Avoid temporary branches created by mergify for parallel checks.
+# These do not work with the pr-validator since the temporary PR
+# branch is updated with a merge commit.
+merge_queue:
+  max_parallel_checks: 1
 
 pull_request_rules:
   - name: default


### PR DESCRIPTION
Problem: Mergify is creating temporary PR branches and merging the main branch (plus possibly other PRs). The merge commit causes the pr-validator to fail, plus in the case of an up-to-date original PR, the checks are redundant.

This is occurring because the maximum parallel checks default was updated to 5 by mergify:

https://changelog.mergify.com/changelog/maxparallelchecks-is-now-5-by-default

Explicitly set max_parallel_checks to 1 to avoid the temporary branches. Also set batch_size to 1 in queue_rules for good measure, since we currently never want to batch up PRs for merging.