### PR TITLE
doc: copy MAINTAINERS, CONTRIBUTING from flux-core

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,18 @@ in the following RFCs from the [flux-framework/rfc][1] project:
     This RFC details the preferred code style guidelines for contributions
     to Flux projects.
 
+ * [*RFC 47: Flux Framework Contributor Code of Conduct*][5]
+
+    Behave!
+
+ * [*RFC 48: Flux Framework Project Governance*][6]
+
+    This RFC describes the rules for the development and community
+    management of Flux projects.
+
 [1]: https://github.com/flux-framework/rfc
 [2]: https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_1.html
 [3]: https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_2.html
 [4]: https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_7.html
+[5]: https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_47.html
+[6]: https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_48.html

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,32 @@
+This document contains a list of the Maintainers of this github repository.
+For further information on the role of Maintainer and how to contribute
+to this project, please refer to [CONTRIBUTING](CONTRIBUTING.md).
+
+## Current Maintainers
+
+| Maintainer       | GitHub ID                                             | Affiliation |
+| ---------------- | ----------------------------------------------------- | ----------- |
+| Al Chu           | [chu11](https://github.com/chu11)                     | LLNL        |
+| Chris Dunlap     | [dun](https://github.com/dun)                         | LLNL        |
+| Chris Moussa     | [cmoussa1](https://github.com/cmoussa1)               | LLNL        |
+| Elsa Gonsiorowski| [gonsie](https://github.com/gonsie)                   | LLNL        |
+| James Corbett    | [jameshcorbett](https://github.com/jameshcorbett)     | LLNL        |
+| Jim Garlick      | [garlick](https://github.com/garlick)                 | LLNL        |
+| Jae-seung Yeom   | [JaeseungYeom](https://github.com/JaeseungYeom)       | LLNL        |
+| Mark Grondona    | [grondo](https://github.com/grondo)                   | LLNL        |
+| Daniel Milroy    | [milroy](https://github.com/milroy)                   | LLNL        |
+| Tapasya Patki    | [tpatki](https://github.com/tpatki)                   | LLNL        |
+| Tom Scogland     | [trws](https://github.com/trws)                       | LLNL        |
+| Vanessa Sochat   | [vsoch](https://github.com/vsoch)                     | LLNL        |
+| Becky Springmeyer| [springme](https://github.com/springme)               | LLNL        |
+| William Hobbs    | [wihobbs](https://github.com/wihobbs)                 | LLNL        |
+
+## Maintainers Emeritus
+
+| Maintainer       | GitHub ID                                             | Affiliation |
+| ---------------- | ----------------------------------------------------- | ----------- |
+| Dong Ahn         | [dongahn](https://github.com/dongahn)                 | NVIDIA      |
+| Don Lipari       | [lipari](https://github.com/lipari)                   | independent |
+| Chris Morrone    | [morrone](https://github.com/morrone)                 | LLNL        |
+| Stephen Herbein  | [steVwonder](https://github.com/steVwonder)           | NVIDIA      |
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,9 @@ ACLOCAL_AMFLAGS = -I config
 EXTRA_DIST = \
 	NEWS.md \
 	README.md \
-	NOTICE.LLNS
+	NOTICE.LLNS \
+	CONTRIBUTING.md \
+	MAINTAINERS.md
 
 SUBDIRS = \
 	src/pam \


### PR DESCRIPTION
Problem:  all flux-framework repositories need a MAINTAINERS.md file, but flux-pam doesn't have one.

Copy MAINTAINERS.md and CONTRIBUTING.md from flux-core.