### PR TITLE
enable readthedocs integration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: doc/requirements.txt

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,2 @@
-sphinx<6.0.0
-sphinx-rtd-theme>=0.5.2
-docutils>=0.14,<0.18
-jinja2<3.1.0
+sphinx>=7.0.0
+sphinx-rtd-theme>=2.0.0


### PR DESCRIPTION
Problem: The flux-pam site isn't auto-building on readthedocs because the config is missing and `doc/requirements.txt` are too old.

Add config and update requirements. (Hopefully the build completes in the PR and we can take a look at the rendered site)