### PR TITLE
NEWS.md: add release notes for v0.3.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+flux-pam version 0.3.0 - 2026-06-04
+-----------------------------------
+
+ * add systemd user slice management and PAM session containment (#19)
+ * support `allow-guest-user` option (#8)
+ * doc: include correct license file (#16)
+ * doc: copy MAINTAINERS, CONTRIBUTING from flux-core (#14)
+ * doc: add `pam_flux(8)` man page (#10)
+ * doc: enable readthedocs integration (#20)
+ * minor code, build, and CI cleanup (#18)
+ * mergify: disable temporary PR branches (#13)
+ * testsuite: use `flux cancel` instead of `flux job cancel` (#11)
+
 flux-pam version 0.2.0 - 2023-10-04
 -----------------------------------
 


### PR DESCRIPTION
Problem: There are no release notes for flux-pam v0.3.0.

Add them to NEWS.md.

I've already added #20 assuming it will go in first.