### PR TITLE
pam: fix `pam_flux.so` interaction with systemd-user PAM service

### DIFF
--- a/doc/man8/pam_flux.rst
+++ b/doc/man8/pam_flux.rst
@@ -143,6 +143,21 @@ session module and are handled by subsequent modules::
 NOTES
 =====
 
+systemd-user Service
+--------------------
+
+``pam_flux.so`` automatically skips when invoked from the systemd-user PAM
+service (the service systemd uses to start ``user@$UID.service``). This
+prevents a circular dependency: the systemd-user stack runs during the
+startup of ``user@$UID.service``, but ``pam_flux.so`` needs to query and
+interact with that service. The module returns ``PAM_IGNORE`` for both
+account and session functions when ``PAM_SERVICE`` is ``systemd-user``.
+
+In practice, ``pam_flux.so`` should not normally appear in
+``/etc/pam.d/systemd-user`` anyway. However, if your site uses shared PAM
+includes (e.g., ``@include common-account``) that bring ``pam_flux.so`` into
+the systemd-user stack, this automatic skip ensures correct behavior.
+
 cgroup v2 Requirement
 ---------------------
 

--- a/src/pam/pam_flux.c
+++ b/src/pam/pam_flux.c
@@ -424,7 +424,6 @@ static int check_user_service_active (pam_handle_t *pamh,
     const char *unit_path_raw = NULL;
     char *unit_path = NULL;
     char *active_state = NULL;
-    char *sub_state = NULL;
     int rc = -1;
 
     *errmsg = "Unable to determine unit state";
@@ -508,23 +507,6 @@ static int check_user_service_active (pam_handle_t *pamh,
     }
     sd_bus_error_free (&error);
 
-    /*  Get SubState property.
-     */
-    if (sd_bus_get_property_string (bus,
-                                    "org.freedesktop.systemd1",
-                                    unit_path,
-                                    "org.freedesktop.systemd1.Unit",
-                                    "SubState",
-                                    &error,
-                                    &sub_state) < 0) {
-        pam_syslog (pamh,
-                    LOG_ERR,
-                    "failed to get SubState for %s: %s",
-                    unit_name,
-                    error.message ? error.message : "unknown error");
-        goto out;
-    }
-
     /* Mirror systemd's own UNIT_IS_ACTIVE_OR_ACTIVATING macro when
      * checking for an active or activating user@UID service:
      */
@@ -546,18 +528,16 @@ static int check_user_service_active (pam_handle_t *pamh,
          */
         pam_syslog (pamh,
                     LOG_INFO,
-                    "%s not running: ActiveState=%s SubState=%s",
+                    "%s not active or activating: ActiveState=%s",
                     unit_name,
-                    active_state,
-                    sub_state);
-        *errmsg = "unit not running";
+                    active_state);
+        *errmsg = "unit not active or activating";
         rc = -1;
     }
 
 out:
     free (unit_path);
     free (active_state);
-    free (sub_state);
     sd_bus_message_unref (reply);
     sd_bus_error_free (&error);
     sd_bus_unref (bus);

--- a/src/pam/pam_flux.c
+++ b/src/pam/pam_flux.c
@@ -754,6 +754,7 @@ PAM_EXTERN int
 pam_sm_acct_mgmt (pam_handle_t *pamh, int flags, int argc, const char **argv)
 {
     const char *user;
+    const char *service = NULL;
     uid_t uid;
     int auth = PAM_PERM_DENIED;
     flux_auth_t result;
@@ -764,6 +765,17 @@ pam_sm_acct_mgmt (pam_handle_t *pamh, int flags, int argc, const char **argv)
 
     if (parse_options (pamh, &opts, argc, argv) < 0)
         return PAM_SYSTEM_ERR;
+
+    /*  Skip systemd-user service - it's starting user@UID.service itself.
+     *  Checking the slice from within that service's own startup is circular
+     *  and not meaningful.
+     */
+    pam_get_item (pamh, PAM_SERVICE, (const void **) &service);
+    if (service && strcmp (service, "systemd-user") == 0) {
+        if (opts.debug)
+            pam_syslog (pamh, LOG_INFO, "skipping for systemd-user service");
+        return PAM_IGNORE;
+    }
 
     result = flux_check_user (pamh, &opts, uid);
     if (result != FLUX_AUTH_DENIED) {
@@ -810,6 +822,7 @@ pam_sm_open_session (pam_handle_t *pamh,
 {
     uid_t uid;
     const char *user;
+    const char *service = NULL;
     const void *pam_flux_authorized = NULL;
     int manage_slice;
     struct options opts = {
@@ -821,6 +834,17 @@ pam_sm_open_session (pam_handle_t *pamh,
 
     if (parse_options (pamh, &opts, argc, argv) < 0)
         return PAM_SESSION_ERR;
+
+    /*  Skip systemd-user service - it's starting user@UID.service itself.
+     *  Creating a scope under user-UID.slice from within that service's own
+     *  startup is circular and not meaningful.
+     */
+    pam_get_item (pamh, PAM_SERVICE, (const void **) &service);
+    if (service && strcmp (service, "systemd-user") == 0) {
+        if (opts.debug)
+            pam_syslog (pamh, LOG_INFO, "skipping for systemd-user service");
+        return PAM_IGNORE;
+    }
 
     /*  Session management decision table:
      *

--- a/src/pam/pam_flux.c
+++ b/src/pam/pam_flux.c
@@ -407,7 +407,8 @@ static int parse_options (pam_handle_t *pamh,
  *  The service is started by the Flux prolog when a job begins and stopped
  *  by housekeeping when the last job ends, so inactive means no active job.
  *
- *  Returns  0 if service is running (ActiveState=active, SubState=running).
+ *  Returns  0 if service is active or activating (mirrors systemd's
+ *             UNIT_IS_ACTIVE_OR_ACTIVATING macro).
  *  Returns -1 if service is not running or an error occurred with specific
  *             reason set in errmsg
  */
@@ -524,12 +525,17 @@ static int check_user_service_active (pam_handle_t *pamh,
         goto out;
     }
 
+    /* Mirror systemd's own UNIT_IS_ACTIVE_OR_ACTIVATING macro when
+     * checking for an active or activating user@UID service:
+     */
     if (strcmp (active_state, "active") == 0
-        && strcmp (sub_state, "running") == 0) {
+        || strcmp (active_state, "activating") == 0
+        || strcmp (active_state, "reloading") == 0
+        || strcmp (active_state, "refreshing") == 0) {
         if (debug)
             pam_syslog (pamh,
                         LOG_INFO,
-                        "%s is active",
+                        "%s is active or activating",
                         unit_name);
         rc = 0;
     }

--- a/t/t0001-pam_flux.t
+++ b/t/t0001-pam_flux.t
@@ -131,4 +131,32 @@ test_expect_success 'pam_flux: access denied if not rank 0 of job' '
 	flux cancel $id &&
 	flux job wait-event -vt 15 $id clean
 '
+test_expect_success 'pam_flux: create systemd-user PAM stack' '
+	cat <<-EOF >systemd-user
+	auth    required   pam_localuser.so
+	account required   ${PAM_FLUX_PATH} debug
+	account required   pam_permit.so
+	EOF
+'
+test_expect_success 'pam_flux: module skips systemd-user service (no job)' '
+	LD_PRELOAD=libpam_wrapper.so \
+	PAM_WRAPPER=1 \
+	PAM_WRAPPER_DEBUGLEVEL=2 \
+	PAM_WRAPPER_SERVICE_DIR=$(pwd) \
+	${PAMTEST} -v -s systemd-user -u ${USER} >systemd-user.out 2>&1 &&
+	test_debug "cat systemd-user.out" &&
+	grep "skipping for systemd-user service" systemd-user.out
+'
+test_expect_success 'pam_flux: module skips systemd-user service (with job)' '
+	jobid=$(flux submit --wait-event=alloc sleep 300) &&
+	LD_PRELOAD=libpam_wrapper.so \
+	PAM_WRAPPER=1 \
+	PAM_WRAPPER_DEBUGLEVEL=2 \
+	PAM_WRAPPER_SERVICE_DIR=$(pwd) \
+	${PAMTEST} -v -s systemd-user -u ${USER} >systemd-user2.out 2>&1 &&
+	test_debug "cat systemd-user2.out" &&
+	grep "skipping for systemd-user service" systemd-user2.out &&
+	flux cancel $jobid &&
+	flux job wait-event -vt 15 $jobid free
+'
 test_done

--- a/t/t0003-pam-session-tests.t
+++ b/t/t0003-pam-session-tests.t
@@ -275,6 +275,35 @@ test_expect_success 'lock-dir-perms: cancel last test job' '
 test_expect_success 'lock-dir-perms: cleanup other-writable directory' '
 	sudo rm -rf bad-lock-dir2
 '
+test_expect_success 'systemd-user: create PAM stack' '
+	cat <<-EOF >systemd-user
+	auth    required   pam_localuser.so
+	account sufficient pam_succeed_if.so uid < 500
+	account sufficient ${PAM_FLUX_PATH}
+	account required   pam_permit.so
+	session requisite  ${PAM_FLUX_PATH} debug
+	session required   pam_unix.so
+	EOF
+'
+test_expect_success 'systemd-user: submit test job' '
+	jobid=$(submit_as_guest 5m sleep 300) &&
+	flux job wait-event $jobid start
+'
+test_expect_success 'systemd-user: session skips systemd-user service' '
+	sudo FLUX_URI=${FLUX_URI} \
+	LD_PRELOAD=libpam_wrapper.so \
+	PAM_WRAPPER=1 \
+	PAM_WRAPPER_DEBUGLEVEL=2 \
+	PAM_WRAPPER_SERVICE_DIR=$(pwd) \
+	${PAMTEST} -v -S -s systemd-user -u ${TEST_USER} \
+		>systemd-user.out 2>&1 &&
+	test_debug "cat systemd-user.out" &&
+	grep "skipping for systemd-user service" systemd-user.out
+'
+test_expect_success 'systemd-user: cancel test job' '
+	flux cancel $jobid &&
+	flux job wait-event -vt 20 $jobid clean
+'
 test_expect_success 'cleanup test scopes' '
 	reset_test_scopes
 '


### PR DESCRIPTION
Problem: When sites use a common system-auth PAM stack, `pam_flux.so` may appear in the `systemd-user` service stack, which is used by systemd when starting the `user@UID` service. This creates circular dependencies:
- `pam_flux.so` session module needs to determine if the `user@UID` service is running, but we're in the middle of starting it
- `pam_flux.so` session module tries to move the current process to a scope under the user slice, but we're starting the user manager, so the slice may not exist, and systemd should handle that anyway.

Additionally, the `pam_flux.so` account module will attempt to check that the user has an active job on the node before allowing the user service to start. This isn't appropriate either, even though it happens to work in our case.

The real fix is probably to keep `pam_flux.so` _out_ of any `systemd-user` PAM stack. However, this may be awkward at many sites with shared `system-auth` PAM configs. Therefore, in both the `pam_flux.so` session and account callbacks, check if the current PAM_SERVICE is `systemd-user` and return `PAM_IGNORE` immediately to work around this issue.

Update the docs to add a note about this new handling of the `systemd-auth` service (in `pam_flux(8)`).

Additionally, improve the check for `user@UID` service in the PAM module to allow active or activating, copying systemd's own ACTIVE_OR_ACTIVATING macro.

Fixes #22 

