### PR TITLE
switch to marker-based slice containment instead of managing user@UID service

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,14 @@ resource constraints as the job.
 
 **Prolog and housekeeping scripts** — `flux-pam-prolog` and
 `flux-pam-housekeeping` run on each compute node at job start and
-completion. They manage the `user@UID.service` lifecycle and, when
-resource constraining is enabled, apply CPU, memory, and device limits
-to the user's systemd slice.
+completion. The prolog applies resource constraints to the user slice,
+creates an active marker file, and best-effort starts `user@UID.service`.
+Housekeeping updates constraints as jobs end and clears the marker when
+the user's last job completes. The PAM session module checks for the
+marker's presence under lock before admitting logins, ensuring
+containment is set up. Slice-based containment works even when
+`user@UID.service` fails to start (e.g., on nodes with `/proc` mounted
+`hidepid=2`).
 
 ## Requirements
 
@@ -88,9 +93,13 @@ account  sufficient  pam_flux.so allow-guest-user
 ### Full configuration with session management
 
 Session management places each login inside the user's systemd slice,
-enforcing the same resource limits as their job. It requires
-`pam.manage-user-slice = true` in the Flux system configuration and the
-prolog/housekeeping scripts to be active (see below).
+enforcing the same resource limits as their job. Logins are admitted only
+when an active marker file exists, which the prolog creates after applying
+constraints and housekeeping removes at last-job teardown. This ensures
+sessions cannot attach before containment is ready or after it has been
+torn down. Session management requires `pam.manage-user-slice = true` in
+the Flux system configuration and the prolog/housekeeping scripts to be
+active (see below).
 
 ```
 # /etc/pam.d/sshd (or equivalent)
@@ -123,7 +132,7 @@ Enable slice lifecycle management and, optionally, resource constraints:
 # /etc/flux/system/conf.d/pam.toml
 
 [pam]
-manage-user-slice = true      # start/stop user@UID.service with jobs
+manage-user-slice = true      # enable slice lifecycle and marker management
 
 [exec]
 service = "sdexec"

--- a/doc/man5/flux-config-pam.rst
+++ b/doc/man5/flux-config-pam.rst
@@ -10,8 +10,8 @@ The ``pam`` table configures flux-pam features that manage systemd user
 slices for Flux job users. This includes:
 
 - The flux-pam prolog and housekeeping scripts, which run during job prolog
-  and housekeeping phases to start/stop user services and optionally apply
-  resource constraints to user slices.
+  and housekeeping phases to manage slice constraints and a per-user active
+  marker, and best-effort attempt to start ``user@$UID.service``.
 - The ``pam_flux.so`` PAM session module, which attaches login sessions
   authenticated via the account module to the user's managed slice when
   ``manage-user-slice`` is enabled. See :man8:`pam_flux`.
@@ -25,14 +25,15 @@ hierarchy. Resource constraints (``AllowedCPUs``, ``AllowedMemoryNodes``,
 ``systemctl set-property --runtime``, which is only enforced by systemd on
 the unified hierarchy. cgroup v1 systems are not supported.
 
-When ``pam.manage-user-slice`` is enabled, Flux takes ownership of the
-``user@UID.service`` manager for job users — starting it at first job and
-stopping it after the last. **systemd linger must not be enabled for job
-users on compute nodes.** Linger (``loginctl enable-linger``) keeps
-``user@UID.service`` running independently of jobs, which interferes with
-Flux's lifecycle management in ways that can cause login sessions to escape
-containment silently. The prolog will fail hard if it detects linger is
-enabled for a job user, rather than proceeding with an inconsistent state.
+When ``pam.manage-user-slice`` is enabled, **systemd linger must not be
+enabled for job users on compute nodes.** Linger (``loginctl enable-linger``)
+keeps ``user@UID.service`` running independently of jobs, bypassing Flux
+control. The prolog fails immediately if linger is detected.
+
+The prolog applies resource constraints to the user slice, creates an
+active marker file, and best-effort starts ``user@$UID.service`` (for
+background, see PROCFS WITH HIDEPID below). The PAM session module checks
+the marker under lock before admitting logins.
 
 The flux-pam package installs ``flux-pam-prolog`` and
 ``flux-pam-housekeeping`` into ``$libexecdir/flux/prolog.d/`` and
@@ -81,22 +82,22 @@ KEYS
 All keys are optional and default to ``false`` unless otherwise noted.
 
 manage-user-slice
-   Boolean value that enables systemd user slice lifecycle
-   management via prolog and housekeeping scripts. When enabled, the
-   prolog starts ``user@UID.service`` (if not already running) for each
-   job user, and housekeeping stops it when the user's last job completes.
+   Boolean value that enables systemd user slice management via prolog and
+   housekeeping scripts. When enabled, the prolog applies slice constraints,
+   publishes the active marker, and best-effort starts ``user@$UID.service``;
+   housekeeping reverts and clears the marker when the last job completes.
    This is the master switch for all user slice management features,
    including session attachment in ``pam_flux.so`` (see :man8:`pam_flux`).
    (Default: ``false``).
 
    When this feature is disabled, prolog and housekeeping scripts exit
-   early without managing user services or applying resource constraints.
-   This includes the instance owner (who always skips management).
+   early without managing user slices or markers. This includes the
+   instance owner (who always skips management).
 
 kill-user-slice
    Boolean value that controls whether housekeeping actively terminates
-   processes remaining in the user slice when stopping
-   ``user@UID.service``. (Default: ``false``).
+   processes remaining in the user slice during last-job slice teardown.
+   (Default: ``false``).
 
    When set to ``true``, housekeeping implements aggressive cleanup:
 
@@ -109,7 +110,7 @@ kill-user-slice
    - Waits for ``kill-slice-grace-time`` again
    - If processes still remain, raises an error and drains the node
 
-   When set to ``false`` (the default), housekeeping stops
+   When set to ``false`` (the default), housekeeping best-effort stops
    ``user@UID.service`` without attempting to kill processes. Cleanup is
    delegated to other mechanisms such as site-specific tools.
 
@@ -155,7 +156,7 @@ exec.sdexec-constrain-resources
      explicitly allowed
 
    When ``exec.sdexec-constrain-resources`` is disabled, prolog/housekeeping
-   still manage the user service lifecycle (start/stop) if
+   still manage the active marker and best-effort start/stop the user manager if
    ``pam.manage-user-slice`` is enabled, but do not apply resource constraints.
 
    See :core:man5:`flux-config-exec` for details on the ``exec`` configuration.
@@ -175,17 +176,22 @@ Prolog scripts run at job start and perform the following actions (when
 2. Check that linger is not enabled for the user (fail hard if it is — see
    PREREQUISITES)
 3. Count active jobs on the node for this user (excluding the starting job)
-4. Start ``user@UID.service`` (idempotent: no-op if already running due to
-   a concurrent prolog for the same user)
-5. If ``exec.sdexec-constrain-resources`` is enabled:
+4. If ``exec.sdexec-constrain-resources`` is enabled:
 
    - Compute the union of resources from all active jobs (including the
      starting job)
    - Query ``sdexec-mapper`` for systemd properties corresponding to the
      resource union
-   - Apply properties to ``user-UID.slice`` via ``systemctl set-property``
+   - Apply properties to ``user-UID.slice`` via ``systemctl set-property
+     --runtime`` (stored even when the slice is inactive; applied when the
+     first scope realizes the slice)
 
-6. Release the lock
+5. Create the per-user active marker file (``/run/flux-pam/uid.$UID.active``)
+6. Best-effort start ``user@UID.service`` (see PROCFS WITH HIDEPID)
+7. Release the lock
+
+The slice itself is automatically realized by systemd  when the first login
+session scope attaches.
 
 Housekeeping Scripts
 --------------------
@@ -200,11 +206,16 @@ actions (when ``pam.manage-user-slice`` is enabled):
    enabled, recalculate and apply resource constraints for the remaining jobs
 4. If no jobs remain (count = 0):
 
+   - Clear the active marker (no new session will be admitted)
+   - Best-effort stop ``user@UID.service`` (failure logged and ignored)
    - If ``pam.kill-user-slice`` is ``true``, perform cleanup sequence
      (see ``kill-user-slice`` above)
-   - Stop ``user@UID.service``
+   - Revert the slice constraint drop-ins (``systemctl revert user-UID.slice``)
 
 5. Release the lock
+
+The empty slice goes dead and is garbage-collected automatically; there is no
+need to explicitly stop the slice.
 
 
 LOCKING AND SERIALIZATION
@@ -215,8 +226,10 @@ on ``/run/flux-pam/uid.UID.lock`` to serialize operations for each user.
 This prevents race conditions when multiple jobs for the same user start
 or complete concurrently on the same node.
 
-The lock is held for the entire duration of prolog/housekeeping execution
-and released automatically when the script exits.
+The lock is held for the entire duration of prolog/housekeeping execution.
+The active marker file is created and removed under this lock, and the PAM
+session module reads it under lock, making session admission linearizable with
+teardown.
 
 The lock directory (``/run/flux-pam`` by default) must have permissions
 ``0700`` (owner read/write/execute only) and be owned by root. Lock files
@@ -226,6 +239,39 @@ operation). If the lock directory has group or other write permissions, both
 the prolog/housekeeping scripts and the PAM session module will refuse to
 proceed and log an error. The directory is created with correct permissions
 at boot by the flux-pam tmpfiles.d drop-in (``/usr/lib/tmpfiles.d/flux-pam.conf``).
+
+
+PROCFS WITH HIDEPID
+===================
+
+The ``hidepid=2`` mount option for ``/proc`` hides other users' processes.
+This breaks ``systemd --user`` startup: the user manager must read
+``/proc/1/cgroup`` to determine the cgroup root, but ``hidepid=2`` hides PID 1
+from unprivileged users (systemd/systemd#12955). Red Hat documents ``hidepid``
+as incompatible with the systemd user manager.
+
+**flux-pam tolerates this.** The prolog makes service start best-effort (failure
+is non-fatal). Containment depends on the slice, not the service: constraints
+are applied with ``systemctl set-property --runtime`` (stored for inactive
+slices) and enforced when the PAM module attaches the login scope. Logins work
+even when ``user@$UID.service`` fails. Repeated service start failures in the
+journal are expected and benign.
+
+**Tradeoff:** No ``systemd --user`` instance means no ``systemctl --user``
+units, user D-Bus, or user timers during jobs. This is normally acceptable on
+batch compute nodes.
+
+**Workaround (weakens hidepid):** To enable the user manager on ``hidepid=2``
+nodes, add the ``gid=`` whitelisted group to ``user@.service``::
+
+   # /etc/systemd/system/user@.service.d/hidepid.conf
+   [Service]
+   SupplementaryGroups=GROUP
+
+Then ``systemctl daemon-reload``. This allows ``systemd --user`` to read
+``/proc/1/cgroup``, but processes started via ``systemctl --user`` inherit the
+group and can see all PIDs. Flux job processes are unaffected (run in separate
+cgroup hierarchy).
 
 
 SECURITY CONSIDERATIONS
@@ -250,9 +296,9 @@ Orphan Processes
 ----------------
 
 With ``kill-user-slice = false`` (the default), processes that outlive a
-user's jobs may remain in the user slice even after ``user@UID.service``
-stops. These processes may retain access to resources that were allocated
-to previous jobs. Sites concerned about this should either:
+user's jobs may remain in the user slice even after the slice is torn down at
+the last job's completion. These processes may retain access to resources that
+were allocated to previous jobs. Sites concerned about this should either:
 
 - Enable ``kill-user-slice`` to forcibly terminate orphans
 - Configure systemd's ``KillMode`` for user slices to handle cleanup

--- a/doc/man8/pam_flux.rst
+++ b/doc/man8/pam_flux.rst
@@ -33,14 +33,11 @@ When ``pam.manage-user-slice`` is enabled in the Flux configuration (see
 :man5:`flux-config-pam`), the session module performs the following for
 each admitted session:
 
-- Acquires a per-user lock (``<lock-dir>/uid.$UID.lock``, default
-  ``/run/flux-pam/uid.$UID.lock``) to serialize service verification and
-  scope creation with the prolog and housekeeping scripts, preventing a
-  race between session setup and concurrent job teardown.
-- Verifies that ``user@$UID.service`` is active. An inactive service
-  indicates the prolog did not complete slice setup successfully; the
-  session is denied to prevent uncontained access pending administrator
-  review.
+- Acquires a per-user lock (``/run/flux-pam/uid.$UID.lock``) to serialize
+  with prolog/housekeeping scripts
+- Checks the active marker file (``/run/flux-pam/uid.$UID.active``). The
+  prolog creates this after applying constraints; housekeeping removes it at
+  last-job teardown. Absence of the marker denies the session.
 - Creates a transient systemd scope (``<scope-prefix>-<pid>.scope``,
   default ``flux-pam-<pid>.scope``) under ``user-$UID.slice`` to contain
   the session processes.
@@ -57,9 +54,8 @@ stacks. Add it as a session provider with the ``requisite`` control field::
 
 See EXAMPLES for a complete stack configuration.
 
-Session management depends on the flux-pam prolog and housekeeping scripts
-to manage the ``user@$UID.service`` lifecycle and user slice properties.
-See :man5:`flux-config-pam`.
+Session management requires the flux-pam prolog and housekeeping scripts (see
+:man5:`flux-config-pam`).
 
 OPTIONS
 =======
@@ -99,7 +95,7 @@ Common Options
 debug
   Enable additional logging. For account management, logs successful grants
   at ``LOG_INFO`` level; failures are always logged regardless. For session
-  management, logs scope creation details and service state checks.
+  management, logs scope creation details and marker checks.
 
 EXAMPLES
 ========
@@ -132,9 +128,9 @@ session module and are handled by subsequent modules::
 
 .. note::
    Place ``pam_flux.so`` first in the session stack. With ``requisite``,
-   a slice setup failure denies the session immediately before any other
-   session module runs. Use ``requisite`` rather than ``required`` or
-   ``optional`` to prevent the user from reaching the node without
+   such that slice setup failure denies the session immediately before any
+   other session module runs. Use ``requisite`` rather than ``required``
+   or ``optional`` to prevent the user from accessing the node without
    containment if setup fails.
 
    Session management is only active when ``pam.manage-user-slice = true``
@@ -146,17 +142,23 @@ NOTES
 systemd-user Service
 --------------------
 
-``pam_flux.so`` automatically skips when invoked from the systemd-user PAM
-service (the service systemd uses to start ``user@$UID.service``). This
-prevents a circular dependency: the systemd-user stack runs during the
-startup of ``user@$UID.service``, but ``pam_flux.so`` needs to query and
-interact with that service. The module returns ``PAM_IGNORE`` for both
-account and session functions when ``PAM_SERVICE`` is ``systemd-user``.
+``pam_flux.so`` returns ``PAM_IGNORE`` when ``PAM_SERVICE`` is
+``systemd-user`` (the PAM stack systemd uses to start ``user@$UID.service``).
+This avoids placing the user manager itself in a flux-pam scope.
 
 In practice, ``pam_flux.so`` should not normally appear in
 ``/etc/pam.d/systemd-user`` anyway. However, if your site uses shared PAM
-includes (e.g., ``@include common-account``) that bring ``pam_flux.so`` into
+includes (e.g., ``include common-account``) that bring ``pam_flux.so`` into
 the systemd-user stack, this automatic skip ensures correct behavior.
+
+/proc with hidepid
+------------------
+
+flux-pam tolerates ``hidepid=2`` on ``/proc``, which breaks
+``user@$UID.service`` startup (see PROCFS WITH HIDEPID in
+:man5:`flux-config-pam`). Logins work even when the user manager
+fails. Tradeoff: no ``systemctl --user`` units, user D-Bus, or user
+timers during jobs.
 
 cgroup v2 Requirement
 ---------------------

--- a/src/bindings/python/Makefile.am
+++ b/src/bindings/python/Makefile.am
@@ -1,1 +1,5 @@
-fluxpy_PYTHON = flux/pam.py
+fluxpy_PYTHON = \
+	flux/pam.py
+
+EXTRA_DIST = \
+	flux/__init__.py

--- a/src/bindings/python/flux/__init__.py
+++ b/src/bindings/python/flux/__init__.py
@@ -1,0 +1,25 @@
+"""flux namespace package"""
+
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)
+
+import os
+
+# Re-export from installed flux-core by executing its __init__.py
+# in our namespace
+import sys
+
+thisdir = os.path.dirname(os.path.dirname(__file__))
+
+# Find installed flux package
+for path in sys.path:
+    if os.path.abspath(path) == os.path.abspath(thisdir):
+        continue
+    flux_init = os.path.join(path, "flux", "__init__.py")
+    if os.path.exists(flux_init):
+        # Execute installed __init__.py in our namespace so its
+        # definitions become ours
+        with open(flux_init) as f:
+            exec(f.read(), globals())
+        break

--- a/src/bindings/python/flux/pam.py
+++ b/src/bindings/python/flux/pam.py
@@ -22,22 +22,8 @@ from flux.job import JobKVSLookup, JobList
 from flux.resource import ResourceSet
 from flux.util import parse_fsd
 
-_debug = False
 
-
-def debug_log(msg):
-    """
-    Log debug message to stderr if FLUX_PAM_SCRIPTS_DEBUG is set or
-    pam.debug is enabled in the Flux configuration.
-
-    Args:
-        msg: Message to log
-    """
-    if _debug or os.environ.get("FLUX_PAM_SCRIPTS_DEBUG"):
-        print(f"flux-pam: {msg}", file=sys.stderr)
-
-
-def acquire_lock(uid, timeout=60, lock_dir=None):
+def acquire_lock(uid, timeout=60, lock_dir="/run/flux-pam"):
     """
     Acquire an exclusive lock for the given UID to serialize operations.
 
@@ -47,7 +33,7 @@ def acquire_lock(uid, timeout=60, lock_dir=None):
     Args:
         uid: User ID to lock
         timeout: Maximum seconds to wait for lock (default: 60)
-        lock_dir: Directory for lock files (default: /run/flux-pam)
+        lock_dir: Directory for lock files
 
     Returns:
         File descriptor of the lock file (caller should hold until done)
@@ -56,9 +42,6 @@ def acquire_lock(uid, timeout=60, lock_dir=None):
         OSError: If lock cannot be acquired within timeout
         ValueError: If lock path is a symlink
     """
-    if lock_dir is None:
-        lock_dir = os.environ.get("FLUX_PAM_LOCK_DIR", "/run/flux-pam")
-
     # Create lock directory if it doesn't exist
     os.makedirs(lock_dir, mode=0o700, exist_ok=True)
 
@@ -183,12 +166,31 @@ class PAMHelper:
         self.handle = flux.Flux()
         self.rank = int(self.handle.attr_get("rank"))
 
-        global _debug
-        if self.handle.conf_get("pam.debug", False):
-            _debug = True
+        # Read all configuration upfront
+        self._debug = (
+            self.handle.conf_get("pam.debug", False)
+            or os.environ.get("FLUX_PAM_SCRIPTS_DEBUG") is not None
+        )
+
+        self.manage_user_slice = self.handle.conf_get(
+            "pam.manage-user-slice", False
+        )
+        self.apply_resources = self.handle.conf_get(
+            "exec.sdexec-constrain-resources", False
+        )
+        self.kill_user_slice = self.handle.conf_get(
+            "pam.kill-user-slice", False
+        )
+        self.kill_grace_time = parse_fsd(
+            self.handle.conf_get("pam.kill-slice-grace-time", "30s")
+        )
+
+        # Set up lock directory and paths
+        self._lock_dir = os.environ.get("FLUX_PAM_LOCK_DIR", "/run/flux-pam")
+        self._marker_path = f"{self._lock_dir}/uid.{userid}.active"
 
         # Acquire lock for this user
-        self._lock_fd = acquire_lock(userid)
+        self._lock_fd = acquire_lock(userid, lock_dir=self._lock_dir)
 
     def __enter__(self):
         """Context manager entry."""
@@ -218,21 +220,7 @@ class PAMHelper:
             return True
 
         # Check master switch (default: false, opt-in)
-        enabled = self.handle.conf_get("pam.manage-user-slice", False)
-        return not enabled
-
-    def should_apply_resources(self):
-        """
-        Check if resource constraints should be applied to user slice.
-
-        This is separate from lifecycle management - when false,
-        prolog/housekeeping still manage user@.service start/stop,
-        but don't apply cpuset/memory/device properties to the slice.
-
-        Returns:
-            True if exec.sdexec-constrain-resources is enabled
-        """
-        return self.handle.conf_get("exec.sdexec-constrain-resources", False)
+        return not self.manage_user_slice
 
     def check_linger(self, timeout=30):
         """
@@ -414,7 +402,7 @@ class PAMHelper:
             # In housekeeping script (exclude ending job):
             helper.apply_resource_constraints("housekeeping")
         """
-        if not self.should_apply_resources():
+        if not self.apply_resources:
             self.debug_log(
                 f"{script_type}: skipping resource constraints "
                 "(exec.sdexec-constrain-resources not enabled)"
@@ -443,7 +431,40 @@ class PAMHelper:
 
     def debug_log(self, msg):
         """Log a debug message prefixed with this job's ID."""
-        debug_log(f"{self.jobid}: {msg}")
+        if self._debug:
+            print(f"flux-pam: {self.jobid}: {msg}", file=sys.stderr)
+
+    def set_active_marker(self):
+        """Create the per-user active marker.
+
+        Called by the prolog after constraints are applied, under the user
+        lock. Presence is the single source of truth the session module uses
+        to admit logins. Idempotent. O_NOFOLLOW refuses symlinks.
+        """
+        fd = os.open(
+            self._marker_path, os.O_CREAT | os.O_WRONLY | os.O_NOFOLLOW, 0o600
+        )
+        os.close(fd)
+
+    def clear_active_marker(self):
+        """Remove the per-user active marker. Idempotent."""
+        try:
+            os.unlink(self._marker_path)
+        except FileNotFoundError:
+            pass
+
+    def revert_slice(self):
+        """Remove Flux-applied resource-control drop-ins from the user slice.
+
+        set-property --runtime stores a drop-in that persists until reboot or
+        revert. Revert on last-job teardown so this job's constraints do not
+        linger. Reverting a slice with no drop-ins is a no-op.
+        """
+        slice_name = f"user-{self.userid}.slice"
+        try:
+            run_subprocess([self.systemctl, "revert", slice_name])
+        except subprocess.CalledProcessError as e:
+            self.debug_log(f"slice revert non-fatal: {e.stderr.strip()}")
 
     def user_service_start(self):
         """Start systemd user service for this user."""
@@ -488,19 +509,6 @@ class PAMHelper:
                     pass
 
         return orphans
-
-    def _get_kill_grace_time(self):
-        """
-        Get configured grace time for kill operations.
-
-        Returns grace time in seconds from pam.kill-slice-grace-time config.
-        Default is 30 seconds.
-
-        Returns:
-            Float number of seconds
-        """
-        grace_config = self.handle.conf_get("pam.kill-slice-grace-time", "30s")
-        return parse_fsd(grace_config)
 
     def _wait_for_slice_empty(self, timeout):
         """
@@ -549,8 +557,6 @@ class PAMHelper:
         Raises:
             RuntimeError: If processes remain after SIGKILL + grace-time
         """
-        grace_time = self._get_kill_grace_time()
-
         # Check if there are any orphan processes to kill
         orphans = self.check_orphan_processes()
         if not orphans:
@@ -560,15 +566,17 @@ class PAMHelper:
         self.debug_log(
             f"Found {len(orphans)} orphan scope(s), starting cleanup"
         )
-        self.debug_log(f"Using grace time: {grace_time}s")
+        self.debug_log(f"Using grace time: {self.kill_grace_time}s")
 
         # Step 1: Send SIGTERM
         self.debug_log("Sending SIGTERM to slice processes")
         self._kill_slice_processes(signal="SIGTERM")
 
         # Step 2: Wait for grace-time
-        self.debug_log(f"Waiting {grace_time}s for processes to exit")
-        if self._wait_for_slice_empty(grace_time):
+        self.debug_log(
+            f"Waiting {self.kill_grace_time}s for processes to exit"
+        )
+        if self._wait_for_slice_empty(self.kill_grace_time):
             self.debug_log("All processes exited after SIGTERM")
             return
 
@@ -580,8 +588,8 @@ class PAMHelper:
         self._kill_slice_processes(signal="SIGKILL")
 
         # Step 4: Wait for grace-time again
-        self.debug_log(f"Waiting {grace_time}s after SIGKILL")
-        if self._wait_for_slice_empty(grace_time):
+        self.debug_log(f"Waiting {self.kill_grace_time}s after SIGKILL")
+        if self._wait_for_slice_empty(self.kill_grace_time):
             self.debug_log("All processes exited after SIGKILL")
             return
 
@@ -589,44 +597,37 @@ class PAMHelper:
         final_orphans = self.check_orphan_processes()
         msg = (
             f"Processes remain in user-{self.userid}.slice after "
-            f"SIGKILL + {grace_time}s grace time: {', '.join(final_orphans)}"
+            f"SIGKILL + {self.kill_grace_time}s grace time: "
+            f"{', '.join(final_orphans)}"
         )
         raise RuntimeError(msg)
 
-    def user_service_stop(self):
+    def user_slice_teardown(self):
+        """Tear down user slice on the user's last job.
+
+        Clear the active marker first so no new session is admitted,
+        best-effort stop the user manager (it may have failed to start,
+        e.g. due to /proc mounted with hidepid=2), run the configured
+        orphan cleanup, then revert the constraint drop-ins. The empty
+        slice goes dead and is garbage-collected automatically; there is
+        no slice to stop.
         """
-        Stop user service, with optional slice cleanup.
+        self.clear_active_marker()
+        service_name = f"user@{self.userid}.service"
+        try:
+            run_subprocess([self.systemctl, "stop", service_name])
+        except subprocess.CalledProcessError as e:
+            self.debug_log(f"user manager stop non-fatal: {e.stderr.strip()}")
 
-        Behavior depends on pam.kill-user-slice config:
-        - false (default): Just stop user@.service. Cleanup not our
-          responsibility - delegated to other mechanisms.
-        - true: Clean up slice with SIGTERM, grace-time, SIGKILL,
-          grace-time, then drain on failure. Grace time is configurable
-          via pam.kill-slice-grace-time (default: 30s).
-
-        Raises:
-            RuntimeError: If kill-user-slice=true and slice still has
-                processes after full cleanup sequence
-        """
-        kill_slice = self.handle.conf_get("pam.kill-user-slice", False)
-
-        # Always stop the service, even if slice cleanup raises.  Cleanup
-        # failure (orphans survive SIGKILL) and service lifecycle are
-        # independent: a stuck process shouldn't leave user@.service running.
         cleanup_error = None
-        if kill_slice:
+        if self.kill_user_slice:
             self.debug_log("kill-user-slice enabled, cleaning up slice")
             try:
                 self._cleanup_user_slice()
             except RuntimeError as e:
                 cleanup_error = e
-        else:
-            self.debug_log(
-                "kill-user-slice disabled, stopping service without cleanup"
-            )
 
-        service_name = f"user@{self.userid}.service"
-        run_subprocess([self.systemctl, "stop", service_name])
+        self.revert_slice()
 
         if cleanup_error:
             raise cleanup_error

--- a/src/pam/pam_flux.c
+++ b/src/pam/pam_flux.c
@@ -23,6 +23,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -403,145 +404,44 @@ static int parse_options (pam_handle_t *pamh,
 }
 
 #ifdef HAVE_LIBSYSTEMD
-/*  Check if user@$UID.service is active and ready for session attachment.
- *  The service is started by the Flux prolog when a job begins and stopped
- *  by housekeeping when the last job ends, so inactive means no active job.
+
+/*  Check the per-user active marker created by the Flux prolog. Its presence,
+ *  read under the user lock, is the single source of truth that the user has
+ *  an active job on the node with containment set up. The prolog creates it
+ *  after applying constraints; housekeeping removes it under the same lock
+ *  when the user's last job ends, so this read cannot race with housekeeping.
  *
- *  Returns  0 if service is active or activating (mirrors systemd's
- *             UNIT_IS_ACTIVE_OR_ACTIVATING macro).
- *  Returns -1 if service is not running or an error occurred with specific
- *             reason set in errmsg
+ *  Returns 0 if the marker is present, -1 otherwise.
  */
-static int check_user_service_active (pam_handle_t *pamh,
-                                      uid_t uid,
-                                      bool debug,
-                                      const char **errmsg)
+static int check_active_marker (pam_handle_t *pamh,
+                                uid_t uid,
+                                const char *lock_dir,
+                                bool debug)
 {
-    sd_bus *bus = NULL;
-    sd_bus_error error = SD_BUS_ERROR_NULL;
-    sd_bus_message *reply = NULL;
-    char unit_name[64];
-    const char *unit_path_raw = NULL;
-    char *unit_path = NULL;
-    char *active_state = NULL;
-    int rc = -1;
+    char path[PATH_MAX];
+    struct stat st;
 
-    *errmsg = "Unable to determine unit state";
-
-    if (snprintf (unit_name,
-                  sizeof (unit_name),
-                  "user@%u.service",
-                  uid) >= sizeof (unit_name)) {
-        pam_syslog (pamh, LOG_ERR, "unit name overflow for uid %u", uid);
+    if (snprintf (path, sizeof (path), "%s/uid.%u.active", lock_dir, uid)
+        >= (int) sizeof (path)) {
+        pam_syslog (pamh, LOG_ERR, "marker path overflow for uid %u", uid);
         return -1;
     }
-
-    /*  Connect to the system bus.
+    /*  lstat so a symlink is not followed; require a regular file.  The
+     *  directory is root-only 0700, so this is defense in depth.
      */
-    if (sd_bus_open_system (&bus) < 0) {
-        pam_syslog (pamh, LOG_ERR, "failed to connect to system bus: %m");
-        return -1;
-    }
-
-    /*  Get the unit object path from systemd.  LoadUnit creates a stub entry
-     *  for units that are not yet loaded, so it always returns a path.
-     */
-    if (sd_bus_call_method (bus,
-                            "org.freedesktop.systemd1",
-                            "/org/freedesktop/systemd1",
-                            "org.freedesktop.systemd1.Manager",
-                            "LoadUnit",
-                            &error,
-                            &reply,
-                            "s",
-                            unit_name) < 0) {
-        pam_syslog (pamh,
-                    LOG_ERR,
-                    "failed to load unit %s: %s",
-                    unit_name,
-                    error.message ? error.message : "unknown error");
-        goto out;
-    }
-
-    if (sd_bus_message_read (reply, "o", &unit_path_raw) < 0) {
-        pam_syslog (pamh, LOG_ERR, "failed to parse LoadUnit response: %m");
-        goto out;
-    }
-
-    /*  unit_path_raw points into the reply message buffer and becomes a
-     *  dangling pointer once the message is unreffed below.  Copy it first.
-     */
-    if (!(unit_path = strdup (unit_path_raw))) {
-        pam_syslog (pamh,
-                    LOG_ERR,
-                    "out of memory copying unit path for %s",
-                    unit_name);
-        goto out;
-    }
-
-    sd_bus_message_unref (reply);
-    reply = NULL;
-    sd_bus_error_free (&error);
-
-    if (debug)
-        pam_syslog (pamh, LOG_INFO,
-                    "checking state of %s at D-Bus path %s",
-                    unit_name,
-                    unit_path);
-
-    /*  Get ActiveState property.
-     */
-    if (sd_bus_get_property_string (bus,
-                                    "org.freedesktop.systemd1",
-                                    unit_path,
-                                    "org.freedesktop.systemd1.Unit",
-                                    "ActiveState",
-                                    &error,
-                                    &active_state) < 0) {
-        pam_syslog (pamh,
-                    LOG_ERR,
-                    "failed to get ActiveState for %s: %s",
-                    unit_name,
-                    error.message ? error.message : "unknown error");
-        goto out;
-    }
-    sd_bus_error_free (&error);
-
-    /* Mirror systemd's own UNIT_IS_ACTIVE_OR_ACTIVATING macro when
-     * checking for an active or activating user@UID service:
-     */
-    if (strcmp (active_state, "active") == 0
-        || strcmp (active_state, "activating") == 0
-        || strcmp (active_state, "reloading") == 0
-        || strcmp (active_state, "refreshing") == 0) {
+    if (lstat (path, &st) < 0) {
         if (debug)
-            pam_syslog (pamh,
-                        LOG_INFO,
-                        "%s is active or activating",
-                        unit_name);
-        rc = 0;
+            pam_syslog (pamh, LOG_INFO, "no active marker for uid %u", uid);
+        return -1;
     }
-    else {
-        /*  inactive/dead is the normal case when no Flux job is running for
-         *  this user (prolog starts the service, housekeeping stops it).
-         *  Always log the observed state so the denial reason is auditable.
-         */
-        pam_syslog (pamh,
-                    LOG_INFO,
-                    "%s not active or activating: ActiveState=%s",
-                    unit_name,
-                    active_state);
-        *errmsg = "unit not active or activating";
-        rc = -1;
+    if (!S_ISREG (st.st_mode)) {
+        pam_syslog (pamh, LOG_ERR,
+                    "active marker for uid %u is not a regular file", uid);
+        return -1;
     }
-
-out:
-    free (unit_path);
-    free (active_state);
-    sd_bus_message_unref (reply);
-    sd_bus_error_free (&error);
-    sd_bus_unref (bus);
-    return rc;
+    if (debug)
+        pam_syslog (pamh, LOG_INFO, "active marker present for uid %u", uid);
+    return 0;
 }
 
 /*  Create a transient scope under user-$UID.slice for the login session.
@@ -899,7 +799,6 @@ pam_sm_open_session (pam_handle_t *pamh,
 #ifdef HAVE_LIBSYSTEMD
     char scope_name[128];
     pid_t pid = getpid ();
-    const char *errmsg = "unknown";
     int lock_fd;
 
     /* Generate scope name
@@ -916,25 +815,23 @@ pam_sm_open_session (pam_handle_t *pamh,
         return PAM_SESSION_ERR;
     }
 
-    /*  Serialize service check + scope creation with prolog/housekeeping to
-     *  prevent a TOCTOU where housekeeping stops the service between our
+    /*  Serialize marker check + scope creation with prolog/housekeeping to
+     *  prevent a TOCTOU where housekeeping removes the marker between our
      *  check and StartTransientUnit.
      */
     if ((lock_fd = user_lock_acquire (pamh, uid, opts.lock_dir)) < 0)
         return PAM_SESSION_ERR;
 
-    /*  Verify user@$UID.service is active before attempting attach.
-     *  The service is started by the Flux prolog and stopped by housekeeping,
-     *  so an inactive service means no active job — deny the login to enforce
-     *  containment.
+    /*  The per-user marker is created by the prolog after containment is
+     *  set up and removed by housekeeping under the same lock held here,
+     *  so its absence authoritatively means no active, contained job for
+     *  this user. Deny to avoid allowing the user unconstrained access
+     *  to the node.
      */
-    if (check_user_service_active (pamh, uid, opts.debug, &errmsg) < 0) {
-        pam_syslog (pamh,
-                    LOG_ERR,
-                    "user %s: user@%u.service: %s. Denying login",
-                    user,
-                    uid,
-                    errmsg);
+    if (check_active_marker (pamh, uid, opts.lock_dir, opts.debug) < 0) {
+        pam_syslog (pamh, LOG_ERR,
+                    "failed session setup for %s: no active job found",
+                    user);
         send_denial_msg (pamh, user, uid);
         user_lock_release (lock_fd);
         return PAM_SESSION_ERR;

--- a/src/scripts/flux-pam-housekeeping.in
+++ b/src/scripts/flux-pam-housekeeping.in
@@ -49,34 +49,31 @@ def main():
     # Use PAMHelper to manage systemd resources
     try:
         with flux.pam.PAMHelper(userid, jobid, systemctl=SYSTEMCTL) as helper:
-            flux.pam.debug_log(
-                f"housekeeping {jobid}: rank={helper.rank} uid={userid}"
+            helper.debug_log(
+                f"housekeeping: rank={helper.rank} uid={userid}"
             )
 
             # Skip if feature disabled or instance owner
             if helper.should_skip():
-                flux.pam.debug_log(
-                    f"housekeeping {jobid}: skipping (disabled or owner)"
-                )
+                helper.debug_log("housekeeping: skipping (disabled or owner)")
                 return 0
 
             # Count remaining active jobs on this rank (excluding ending job)
             count = helper.active_local_jobs()
-            flux.pam.debug_log(
-                f"housekeeping {jobid}: {count} jobs remain for uid={userid}"
+            helper.debug_log(
+                f"housekeeping: {count} jobs remain for uid={userid}"
             )
 
-            # If no jobs remain (N→0), stop user service
+            # If no jobs remain (N→0), tear down: clear the marker, best-effort
+            # stop the manager, run configured cleanup, and revert constraints.
             if count == 0:
-                flux.pam.debug_log(
-                    f"housekeeping {jobid}: stopping user@{userid}.service"
+                helper.debug_log(
+                    f"housekeeping: tearing down slice for uid={userid}"
                 )
-                helper.user_service_stop()
+                helper.user_slice_teardown()
             else:
-                # Update slice properties for remaining jobs
-                flux.pam.debug_log(
-                    f"housekeeping {jobid}: updating slice for "
-                    f"{count} remaining jobs"
+                helper.debug_log(
+                    f"housekeeping: updating slice for {count} remaining jobs"
                 )
                 helper.apply_resource_constraints("housekeeping")
 

--- a/src/scripts/flux-pam-prolog.in
+++ b/src/scripts/flux-pam-prolog.in
@@ -50,13 +50,13 @@ def main():
         with flux.pam.PAMHelper(
             userid, jobid, systemctl=SYSTEMCTL, loginctl=LOGINCTL
         ) as helper:
-            flux.pam.debug_log(
-                f"prolog {jobid}: rank={helper.rank} uid={userid}"
+            helper.debug_log(
+                f"prolog: rank={helper.rank} uid={userid}"
             )
 
             # Skip if feature disabled or instance owner
             if helper.should_skip():
-                flux.pam.debug_log(f"prolog {jobid}: skipping (disabled or owner)")
+                helper.debug_log("prolog: skipping (disabled or owner)")
                 return 0
 
             # Check if linger is enabled (must be disabled)
@@ -67,7 +67,7 @@ def main():
                         file=sys.stderr,
                     )
                     return 1
-                flux.pam.debug_log(f"prolog {jobid}: linger check passed")
+                helper.debug_log("prolog: linger check passed")
             except (subprocess.TimeoutExpired, ValueError) as e:
                 print(
                     f"flux-pam-prolog[{jobid}]: linger check failed: {e}",
@@ -77,22 +77,14 @@ def main():
 
             # Count other active jobs on this rank for resource constraints
             count = helper.active_local_jobs()
-            flux.pam.debug_log(
-                f"prolog {jobid}: found {count} other active jobs for uid={userid}"
+            helper.debug_log(
+                f"prolog: found {count} other active jobs for uid={userid}"
             )
 
-            # Start user service (idempotent: no-op if already running)
-            flux.pam.debug_log(f"prolog {jobid}: starting user@{userid}.service")
-            try:
-                helper.user_service_start()
-            except Exception as e:
-                print(
-                    f"flux-pam-prolog[{jobid}]: failed to start service: {e}",
-                    file=sys.stderr,
-                )
-                return 1
-
-            # Apply resource constraints (includes current job)
+            # Apply resource constraints to the user slice (includes current
+            # job). set-property stores the drop-in even when the slice is
+            # inactive; it is applied when the first login scope realizes the
+            # slice.
             try:
                 helper.apply_resource_constraints(
                     "prolog", include_current=True
@@ -103,6 +95,32 @@ def main():
                     file=sys.stderr,
                 )
                 return 1
+
+            # Publish the active marker after constraints are in place. Its
+            # presence under the user lock is the single source of truth the
+            # session module uses to admit logins.
+            try:
+                helper.set_active_marker()
+            except Exception as e:
+                print(
+                    f"flux-pam-prolog[{jobid}]: failed to set active marker: {e}",
+                    file=sys.stderr,
+                )
+                return 1
+
+            # Best-effort user manager start. Failure (e.g. hidepid, where
+            # systemd --user cannot read /proc/1/cgroup) is non-fatal: the slice
+            # is realized with the stored constraints when the first login scope
+            # attaches.
+            helper.debug_log(
+                f"prolog: starting user@{userid}.service (best-effort)"
+            )
+            try:
+                helper.user_service_start()
+            except Exception as e:
+                helper.debug_log(
+                    f"prolog: user manager start failed (non-fatal): {e}"
+                )
 
     except Exception as e:
         print(f"flux-pam-prolog[{jobid}]: error: {e}", file=sys.stderr)

--- a/t/python/subflux.py
+++ b/t/python/subflux.py
@@ -77,6 +77,11 @@ def rerun_under_flux(size=1, personality="full"):
     if "FLUX_BUILD_DIR" in os.environ:
         child_env["FLUX_BUILD_DIR"] = os.environ["FLUX_BUILD_DIR"]
 
+    # Ensure flux.pam in builddir overrides installed flux.pam
+    child_env["FLUX_PYTHONPATH_PREPEND"] = (
+        script_dir + "/../../src/bindings/python"
+    )
+
     sanitize_env(child_env)
 
     command = [flux_exe, "start", "--test-size", str(size)]

--- a/t/python/t0001-pam.py
+++ b/t/python/t0001-pam.py
@@ -240,71 +240,15 @@ class TestPAMHelper(unittest.TestCase):
             with flux.pam.PAMHelper(uid, 12345) as helper:
                 owner_uid = int(helper.handle.attr_get("security.owner"))
 
-                # Mock conf_get to check correct key and return False
-                def mock_conf_get_disabled(key, default):
-                    if key == "pam.manage-user-slice":
-                        return False
-                    return default
+                # Set manage_user_slice to False
+                helper.manage_user_slice = False
+                self.assertTrue(helper.should_skip())
 
-                with patch.object(
-                    helper.handle,
-                    "conf_get",
-                    side_effect=mock_conf_get_disabled,
-                ):
-                    self.assertTrue(helper.should_skip())
-
-                # Mock conf_get to return True (enabled)
-                def mock_conf_get_enabled(key, default):
-                    if key == "pam.manage-user-slice":
-                        return True
-                    return default
-
-                with patch.object(
-                    helper.handle,
-                    "conf_get",
-                    side_effect=mock_conf_get_enabled,
-                ):
-                    # Should not skip (unless we're instance owner)
-                    if uid != owner_uid:
-                        self.assertFalse(helper.should_skip())
-        finally:
-
-            shutil.rmtree(os.environ["FLUX_PAM_LOCK_DIR"], ignore_errors=True)
-            del os.environ["FLUX_PAM_LOCK_DIR"]
-
-    def test_should_apply_resources(self):
-        """
-        Test should_apply_resources checks exec.sdexec-constrain-resources
-        """
-        uid = os.getuid()
-        os.environ["FLUX_PAM_LOCK_DIR"] = tempfile.mkdtemp()
-        try:
-            with flux.pam.PAMHelper(uid, 12345) as helper:
-                # Mock conf_get to return False for sdexec-constrain-resources
-                def mock_conf_get_no_resources(key, default):
-                    if key == "exec.sdexec-constrain-resources":
-                        return False
-                    return default
-
-                with patch.object(
-                    helper.handle,
-                    "conf_get",
-                    side_effect=mock_conf_get_no_resources,
-                ):
-                    self.assertFalse(helper.should_apply_resources())
-
-                # Mock conf_get to return True for sdexec-constrain-resources
-                def mock_conf_get_with_resources(key, default):
-                    if key == "exec.sdexec-constrain-resources":
-                        return True
-                    return default
-
-                with patch.object(
-                    helper.handle,
-                    "conf_get",
-                    side_effect=mock_conf_get_with_resources,
-                ):
-                    self.assertTrue(helper.should_apply_resources())
+                # Set manage_user_slice to True
+                helper.manage_user_slice = True
+                # Should not skip (unless we're instance owner)
+                if uid != owner_uid:
+                    self.assertFalse(helper.should_skip())
         finally:
 
             shutil.rmtree(os.environ["FLUX_PAM_LOCK_DIR"], ignore_errors=True)
@@ -373,6 +317,67 @@ class TestPAMHelper(unittest.TestCase):
                 helper.modify_slice(None)
         finally:
 
+            shutil.rmtree(os.environ["FLUX_PAM_LOCK_DIR"], ignore_errors=True)
+            del os.environ["FLUX_PAM_LOCK_DIR"]
+
+    def test_set_active_marker(self):
+        """Test set_active_marker creates marker file"""
+        uid = os.getuid()
+        os.environ["FLUX_PAM_LOCK_DIR"] = tempfile.mkdtemp()
+        try:
+            with flux.pam.PAMHelper(uid, 12345) as helper:
+                # Marker should not exist initially
+                self.assertFalse(os.path.exists(helper._marker_path))
+
+                # Create marker
+                helper.set_active_marker()
+
+                # Marker should exist now
+                self.assertTrue(os.path.exists(helper._marker_path))
+                # Should be a regular file
+                self.assertTrue(os.path.isfile(helper._marker_path))
+                # Should have correct permissions (0600)
+                st = os.stat(helper._marker_path)
+                self.assertEqual(st.st_mode & 0o777, 0o600)
+        finally:
+            shutil.rmtree(os.environ["FLUX_PAM_LOCK_DIR"], ignore_errors=True)
+            del os.environ["FLUX_PAM_LOCK_DIR"]
+
+    def test_clear_active_marker(self):
+        """Test clear_active_marker removes marker file"""
+        uid = os.getuid()
+        os.environ["FLUX_PAM_LOCK_DIR"] = tempfile.mkdtemp()
+        try:
+            with flux.pam.PAMHelper(uid, 12345) as helper:
+                # Create marker first
+                helper.set_active_marker()
+                self.assertTrue(os.path.exists(helper._marker_path))
+
+                # Clear marker
+                helper.clear_active_marker()
+
+                # Marker should not exist
+                self.assertFalse(os.path.exists(helper._marker_path))
+
+                # Clearing again should be idempotent (not raise)
+                helper.clear_active_marker()
+        finally:
+            shutil.rmtree(os.environ["FLUX_PAM_LOCK_DIR"], ignore_errors=True)
+            del os.environ["FLUX_PAM_LOCK_DIR"]
+
+    def test_marker_refuses_symlink(self):
+        """Test set_active_marker refuses to follow symlinks"""
+        uid = os.getuid()
+        os.environ["FLUX_PAM_LOCK_DIR"] = tempfile.mkdtemp()
+        try:
+            with flux.pam.PAMHelper(uid, 12345) as helper:
+                # Create symlink at marker path
+                os.symlink("/tmp/fake", helper._marker_path)
+
+                # Should raise when trying to create marker
+                with self.assertRaises(OSError):
+                    helper.set_active_marker()
+        finally:
             shutil.rmtree(os.environ["FLUX_PAM_LOCK_DIR"], ignore_errors=True)
             del os.environ["FLUX_PAM_LOCK_DIR"]
 
@@ -742,8 +747,8 @@ class TestPAMHelperErrors(unittest.TestCase):
             shutil.rmtree(os.environ["FLUX_PAM_LOCK_DIR"], ignore_errors=True)
             del os.environ["FLUX_PAM_LOCK_DIR"]
 
-    def test_user_service_stop_failure(self):
-        """Test user_service_stop when systemctl fails"""
+    def test_user_slice_teardown_best_effort(self):
+        """Test user_slice_teardown tolerates systemctl failures"""
         uid = os.getuid()
         os.environ["FLUX_PAM_LOCK_DIR"] = tempfile.mkdtemp()
         try:
@@ -754,9 +759,8 @@ class TestPAMHelperErrors(unittest.TestCase):
                         1, ["systemctl", "stop"], stderr="Service not found"
                     )
 
-                    # Should raise exception
-                    with self.assertRaises(subprocess.CalledProcessError):
-                        helper.user_service_stop()
+                    # Should NOT raise exception (best-effort)
+                    helper.user_slice_teardown()
         finally:
 
             shutil.rmtree(os.environ["FLUX_PAM_LOCK_DIR"], ignore_errors=True)
@@ -790,20 +794,6 @@ class TestPAMHelperErrors(unittest.TestCase):
 
             shutil.rmtree(os.environ["FLUX_PAM_LOCK_DIR"], ignore_errors=True)
             del os.environ["FLUX_PAM_LOCK_DIR"]
-
-    def test_systemctl_path_is_used(self):
-        """Test PAMHelper uses the systemctl path given to constructor"""
-        uid = os.getuid()
-        os.environ["FLUX_PAM_LOCK_DIR"] = tempfile.mkdtemp()
-        try:
-            with flux.pam.PAMHelper(
-                uid, 12345, systemctl="/test/mock-systemctl"
-            ) as helper:
-                self.assertEqual(helper.systemctl, "/test/mock-systemctl")
-        finally:
-            shutil.rmtree(
-                os.environ.pop("FLUX_PAM_LOCK_DIR"), ignore_errors=True
-            )
 
 
 class TestPAMHelperWithMapper(unittest.TestCase):
@@ -899,189 +889,40 @@ class TestPAMHelperWithMapper(unittest.TestCase):
             del os.environ["FLUX_PAM_LOCK_DIR"]
 
 
-class TestApplyResourceConstraints(unittest.TestCase):
-    """Test apply_resource_constraints helper method"""
-
-    def test_apply_resource_constraints_includes_current(self):
-        """Test apply_resource_constraints with include_current=True"""
-        uid = 12345
-        os.environ["FLUX_PAM_LOCK_DIR"] = tempfile.mkdtemp()
-        try:
-            with patch("flux.Flux") as mock_flux:
-                helper = flux.pam.PAMHelper(uid, flux.job.JobID(1))
-                helper.handle = mock_flux
-
-                # Mock should_apply_resources to return True
-                helper.handle.conf_get = lambda key, default: (
-                    True
-                    if key == "exec.sdexec-constrain-resources"
-                    else default
-                )
-
-                # Mock the methods that will be called
-                with patch.object(
-                    helper, "resource_union", return_value={"mock": "R"}
-                ) as mock_union:
-                    with patch.object(
-                        helper,
-                        "lookup_properties",
-                        return_value={"CPUAccounting": "yes"},
-                    ) as mock_lookup:
-                        with patch.object(
-                            helper, "modify_slice"
-                        ) as mock_modify:
-                            # Call with include_current=True
-                            helper.apply_resource_constraints(
-                                "prolog", include_current=True
-                            )
-
-                            # Verify resource_union called with
-                            # include_current=True
-                            mock_union.assert_called_once_with(
-                                include_current=True
-                            )
-                            # Verify lookup_properties called with R
-                            mock_lookup.assert_called_once_with({"mock": "R"})
-                            # Verify modify_slice called with properties
-                            mock_modify.assert_called_once_with(
-                                {"CPUAccounting": "yes"}
-                            )
-        finally:
-            shutil.rmtree(os.environ["FLUX_PAM_LOCK_DIR"], ignore_errors=True)
-            del os.environ["FLUX_PAM_LOCK_DIR"]
-
-    def test_apply_resource_constraints_excludes_current(self):
-        """Test apply_resource_constraints with include_current=False"""
-        uid = 12345
-        os.environ["FLUX_PAM_LOCK_DIR"] = tempfile.mkdtemp()
-        try:
-            with patch("flux.Flux") as mock_flux:
-                helper = flux.pam.PAMHelper(uid, flux.job.JobID(1))
-                helper.handle = mock_flux
-
-                helper.handle.conf_get = lambda key, default: (
-                    True
-                    if key == "exec.sdexec-constrain-resources"
-                    else default
-                )
-
-                with patch.object(
-                    helper, "resource_union", return_value={"mock": "R"}
-                ) as mock_union:
-                    with patch.object(
-                        helper,
-                        "lookup_properties",
-                        return_value={"CPUAccounting": "yes"},
-                    ):
-                        with patch.object(helper, "modify_slice"):
-                            # Call with include_current=False (default)
-                            helper.apply_resource_constraints("housekeeping")
-
-                            # Verify resource_union called with
-                            # include_current=False
-                            mock_union.assert_called_once_with(
-                                include_current=False
-                            )
-        finally:
-            shutil.rmtree(os.environ["FLUX_PAM_LOCK_DIR"], ignore_errors=True)
-            del os.environ["FLUX_PAM_LOCK_DIR"]
-
-    def test_apply_resource_constraints_skips_when_disabled(self):
-        """Test apply_resource_constraints respects should_apply_resources"""
-        uid = 12345
-        os.environ["FLUX_PAM_LOCK_DIR"] = tempfile.mkdtemp()
-        try:
-            with patch("flux.Flux") as mock_flux:
-                helper = flux.pam.PAMHelper(uid, flux.job.JobID(1))
-                helper.handle = mock_flux
-
-                # Mock should_apply_resources to return False
-                helper.handle.conf_get = lambda key, default: False
-
-                with patch.object(helper, "resource_union") as mock_union:
-                    with patch.object(
-                        helper, "lookup_properties"
-                    ) as mock_lookup:
-                        with patch.object(
-                            helper, "modify_slice"
-                        ) as mock_modify:
-                            # Call helper
-                            helper.apply_resource_constraints("prolog")
-
-                            # Verify none of the methods were called
-                            mock_union.assert_not_called()
-                            mock_lookup.assert_not_called()
-                            mock_modify.assert_not_called()
-        finally:
-            shutil.rmtree(os.environ["FLUX_PAM_LOCK_DIR"], ignore_errors=True)
-            del os.environ["FLUX_PAM_LOCK_DIR"]
-
-    def test_apply_resource_constraints_with_empty_properties(self):
-        """Test apply_resource_constraints when no properties returned"""
-        uid = 12345
-        os.environ["FLUX_PAM_LOCK_DIR"] = tempfile.mkdtemp()
-        try:
-            with patch("flux.Flux") as mock_flux:
-                helper = flux.pam.PAMHelper(uid, flux.job.JobID(1))
-                helper.handle = mock_flux
-
-                helper.handle.conf_get = lambda key, default: (
-                    True
-                    if key == "exec.sdexec-constrain-resources"
-                    else default
-                )
-
-                with patch.object(helper, "resource_union", return_value={}):
-                    # lookup_properties returns empty dict (no mapper)
-                    with patch.object(
-                        helper, "lookup_properties", return_value={}
-                    ):
-                        with patch.object(
-                            helper, "modify_slice"
-                        ) as mock_modify:
-                            helper.apply_resource_constraints("housekeeping")
-
-                            # modify_slice should not be called with
-                            # empty properties
-                            mock_modify.assert_not_called()
-        finally:
-            shutil.rmtree(os.environ["FLUX_PAM_LOCK_DIR"], ignore_errors=True)
-            del os.environ["FLUX_PAM_LOCK_DIR"]
-
-
 class TestKillUserSlice(unittest.TestCase):
     """Test kill-user-slice functionality"""
 
     def test_kill_user_slice_no_orphans_skips_cleanup(self):
         """
-        Test user_service_stop when no orphans exist
+        Test user_slice_teardown when no orphans exist
         """
         uid = 12345
         os.environ["FLUX_PAM_LOCK_DIR"] = tempfile.mkdtemp()
         try:
             with patch("flux.Flux") as mock_flux:
+                # Setup default conf_get mock to return sensible defaults
+                mock_flux.return_value.conf_get.side_effect = (
+                    lambda key, default: default
+                )
                 helper = flux.pam.PAMHelper(uid, flux.job.JobID(1))
-                helper.handle = mock_flux
 
-                # Mock conf_get
-                def mock_conf_get(key, default):
-                    if key == "pam.kill-user-slice":
-                        return True
-                    return default
-
-                helper.handle.conf_get = mock_conf_get
+                # Set config attribute
+                helper.kill_user_slice = True
 
                 # No orphans - cleanup should be skipped
                 with patch.object(
                     helper, "check_orphan_processes", return_value=[]
                 ):
                     with patch("flux.pam.run_subprocess") as mock_run:
-                        helper.user_service_stop()
+                        helper.user_slice_teardown()
 
-                        # Should only call stop (no kill since no orphans)
-                        self.assertEqual(mock_run.call_count, 1)
+                        # Should call stop and revert
+                        # (no kill since no orphans)
+                        self.assertEqual(mock_run.call_count, 2)
                         call_str = str(mock_run.call_args_list[0])
                         self.assertIn("stop", call_str)
+                        call_str = str(mock_run.call_args_list[1])
+                        self.assertIn("revert", call_str)
         finally:
             shutil.rmtree(os.environ["FLUX_PAM_LOCK_DIR"], ignore_errors=True)
             del os.environ["FLUX_PAM_LOCK_DIR"]
@@ -1094,17 +935,15 @@ class TestKillUserSlice(unittest.TestCase):
         os.environ["FLUX_PAM_LOCK_DIR"] = tempfile.mkdtemp()
         try:
             with patch("flux.Flux") as mock_flux:
+                # Setup default conf_get mock to return sensible defaults
+                mock_flux.return_value.conf_get.side_effect = (
+                    lambda key, default: default
+                )
                 helper = flux.pam.PAMHelper(uid, flux.job.JobID(1))
-                helper.handle = mock_flux
 
-                def mock_conf_get(key, default):
-                    if key == "pam.kill-user-slice":
-                        return True
-                    if key == "pam.kill-slice-grace-time":
-                        return "0.1s"  # Fast timeout for tests
-                    return default
-
-                helper.handle.conf_get = mock_conf_get
+                # Set config attributes
+                helper.kill_user_slice = True
+                helper.kill_grace_time = 0.1  # Fast timeout for tests
 
                 # First call: orphans exist, then they're gone
                 orphan_calls = [["scope1"], []]
@@ -1114,10 +953,10 @@ class TestKillUserSlice(unittest.TestCase):
                     side_effect=orphan_calls,
                 ):
                     with patch("flux.pam.run_subprocess") as mock_run:
-                        helper.user_service_stop()
+                        helper.user_slice_teardown()
 
-                        # Should call kill (SIGTERM) then stop
-                        self.assertEqual(mock_run.call_count, 2)
+                        # Should call stop, kill (SIGTERM), revert
+                        self.assertEqual(mock_run.call_count, 3)
                         calls = [str(call) for call in mock_run.call_args_list]
                         self.assertTrue(
                             any("SIGTERM" in c for c in calls),
@@ -1127,13 +966,17 @@ class TestKillUserSlice(unittest.TestCase):
                             any("stop" in c for c in calls),
                             "Should stop service",
                         )
+                        self.assertTrue(
+                            any("revert" in c for c in calls),
+                            "Should revert slice",
+                        )
         finally:
             shutil.rmtree(os.environ["FLUX_PAM_LOCK_DIR"], ignore_errors=True)
             del os.environ["FLUX_PAM_LOCK_DIR"]
 
     def test_kill_user_slice_config_false_ignores_orphans(self):
         """
-        Test user_service_stop with kill-user-slice=false just stops service
+        Test user_slice_teardown with kill-user-slice=false just stops service
 
         When kill=false, cleanup is delegated elsewhere, so we ignore orphans
         and just stop the service.
@@ -1142,16 +985,14 @@ class TestKillUserSlice(unittest.TestCase):
         os.environ["FLUX_PAM_LOCK_DIR"] = tempfile.mkdtemp()
         try:
             with patch("flux.Flux") as mock_flux:
+                # Setup default conf_get mock to return sensible defaults
+                mock_flux.return_value.conf_get.side_effect = (
+                    lambda key, default: default
+                )
                 helper = flux.pam.PAMHelper(uid, flux.job.JobID(1))
-                helper.handle = mock_flux
 
-                # Mock conf_get to return false for kill-user-slice
-                def mock_conf_get(key, default):
-                    if key == "pam.kill-user-slice":
-                        return False
-                    return default
-
-                helper.handle.conf_get = mock_conf_get
+                # Set kill_user_slice to False
+                helper.kill_user_slice = False
 
                 # Mock check_orphan_processes - should NOT be called
                 with patch.object(
@@ -1160,12 +1001,14 @@ class TestKillUserSlice(unittest.TestCase):
                     return_value=["session-123.scope: 2 process(es)"],
                 ) as mock_orphans:
                     with patch("flux.pam.run_subprocess") as mock_run:
-                        helper.user_service_stop()
+                        helper.user_slice_teardown()
 
-                        # Should only call stop (no kill)
-                        self.assertEqual(mock_run.call_count, 1)
+                        # Should call stop and revert (no kill)
+                        self.assertEqual(mock_run.call_count, 2)
                         call_str = str(mock_run.call_args_list[0])
                         self.assertIn("stop", call_str)
+                        call_str = str(mock_run.call_args_list[1])
+                        self.assertIn("revert", call_str)
 
                         # Should NOT check for orphans
                         mock_orphans.assert_not_called()
@@ -1181,17 +1024,15 @@ class TestKillUserSlice(unittest.TestCase):
         os.environ["FLUX_PAM_LOCK_DIR"] = tempfile.mkdtemp()
         try:
             with patch("flux.Flux") as mock_flux:
+                # Setup default conf_get mock to return sensible defaults
+                mock_flux.return_value.conf_get.side_effect = (
+                    lambda key, default: default
+                )
                 helper = flux.pam.PAMHelper(uid, flux.job.JobID(1))
-                helper.handle = mock_flux
 
-                def mock_conf_get(key, default):
-                    if key == "pam.kill-user-slice":
-                        return True
-                    if key == "pam.kill-slice-grace-time":
-                        return "0.05s"  # Very short for faster test
-                    return default
-
-                helper.handle.conf_get = mock_conf_get
+                # Set config attributes
+                helper.kill_user_slice = True
+                helper.kill_grace_time = 0.05  # Very short for faster test
 
                 # Track which phase we're in based on subprocess calls
                 kill_count = [0]
@@ -1217,7 +1058,7 @@ class TestKillUserSlice(unittest.TestCase):
                 ):
                     with patch("flux.pam.run_subprocess") as mock_run:
                         mock_run.side_effect = mock_run_subprocess
-                        helper.user_service_stop()
+                        helper.user_slice_teardown()
 
                         # Should send both SIGTERM and SIGKILL
                         calls = [str(call) for call in mock_run.call_args_list]
@@ -1239,7 +1080,7 @@ class TestKillUserSlice(unittest.TestCase):
 
     def test_kill_user_slice_config_true_orphans_remain(self):
         """
-        Test user_service_stop with kill=true raises if orphans remain
+        Test user_slice_teardown with kill=true raises if orphans remain
 
         When kill=true and orphans remain after SIGKILL + grace time, the
         RuntimeError is still raised but only AFTER systemctl stop is called.
@@ -1248,17 +1089,15 @@ class TestKillUserSlice(unittest.TestCase):
         os.environ["FLUX_PAM_LOCK_DIR"] = tempfile.mkdtemp()
         try:
             with patch("flux.Flux") as mock_flux:
+                # Setup default conf_get mock to return sensible defaults
+                mock_flux.return_value.conf_get.side_effect = (
+                    lambda key, default: default
+                )
                 helper = flux.pam.PAMHelper(uid, flux.job.JobID(1))
-                helper.handle = mock_flux
 
-                def mock_conf_get(key, default):
-                    if key == "pam.kill-user-slice":
-                        return True
-                    if key == "pam.kill-slice-grace-time":
-                        return "0.1s"
-                    return default
-
-                helper.handle.conf_get = mock_conf_get
+                # Set config attributes
+                helper.kill_user_slice = True
+                helper.kill_grace_time = 0.1
 
                 # Orphans persist through everything
                 with patch.object(
@@ -1269,7 +1108,7 @@ class TestKillUserSlice(unittest.TestCase):
                     with patch("flux.pam.run_subprocess") as mock_run:
                         # Should raise RuntimeError
                         with self.assertRaises(RuntimeError) as cm:
-                            helper.user_service_stop()
+                            helper.user_slice_teardown()
 
                         self.assertIn(
                             "Processes remain in user-12345.slice",

--- a/t/t0002-prolog-housekeeping.t
+++ b/t/t0002-prolog-housekeeping.t
@@ -16,13 +16,15 @@ HOUSEKEEPING=${FLUX_BUILD_DIR}/src/scripts/flux-pam-housekeeping
 SCRIPTSDIR=${SHARNESS_TEST_SRCDIR}/scripts
 export FLUX_PAM_TEST_SYSTEMCTL=${SCRIPTSDIR}/mock-systemctl
 export FLUX_PAM_TEST_LOGINCTL=${SCRIPTSDIR}/mock-loginctl
-export PYTHONPATH=${FLUX_SOURCE_DIR}/src/bindings/python:${PYTHONPATH}
 
 # Use temporary dir for lock files
 export FLUX_PAM_LOCK_DIR=$(pwd)/lock
 
 # Enable debug logging from prolog/housekeeping
 export FLUX_PAM_SCRIPTS_DEBUG=1
+
+# Ensure flux python loads from source directory
+export FLUX_PYTHONPATH_PREPEND=${FLUX_SOURCE_DIR}/src/bindings/python
 
 test_under_flux 4
 

--- a/t/t0002-prolog-housekeeping.t
+++ b/t/t0002-prolog-housekeeping.t
@@ -130,18 +130,22 @@ test_expect_success 're-enable pam.manage-user-slice for remaining tests' '
 	EOT
 '
 # Single job start/end:
-# Prolog should start user@42.service and call set-property
+# Prolog should apply constraints, publish marker, and start user service
 test_expect_success 'submit a test job on rank 0' '
 	jobid=$(submit_as_guest 5m --requires="rank:0" sleep 300) &&
 	echo $jobid > jobid.0 &&
 	flux job wait-event -v $jobid start
 '
-test_expect_success 'jobid.0: prolog started user service and set-properties' '
+test_expect_success 'jobid.0: prolog applied constraints and published marker' '
 	jobid=$(cat jobid.0) &&
 	test_debug "cat systemctl-${jobid}.log" &&
-	grep "start user@42.service" systemctl-${jobid}.log &&
 	grep "set-property --runtime user-42.slice" systemctl-${jobid}.log &&
+	test -f ${FLUX_PAM_LOCK_DIR}/uid.42.active &&
 	test_must_fail grep "stop user@42.service" systemctl-${jobid}.log
+'
+test_expect_success 'jobid.0: prolog started user service (best-effort)' '
+	jobid=$(cat jobid.0) &&
+	grep "start user@42.service" systemctl-${jobid}.log
 '
 
 # MULTICORE-only tests follow:
@@ -149,6 +153,9 @@ test_expect_success MULTICORE 'submit second job on rank 0' '
 	jobid=$(submit_as_guest 5m --requires="rank:0" sleep 300) &&
 	flux job wait-event $jobid start &&
 	echo $jobid > jobid.1
+'
+test_expect_success MULTICORE 'jobid.1: marker still present (concurrent job)' '
+	test -f ${FLUX_PAM_LOCK_DIR}/uid.42.active
 '
 test_expect_success MULTICORE 'jobid.1: prolog started user service (idempotent)' '
 	jobid=$(cat jobid.1) &&
@@ -171,7 +178,10 @@ test_expect_success MULTICORE 'jobid.0: housekeeping runs set-property' '
 	grep "set-property .* user-42.slice" systemctl-${jobid}.log &&
 	grep "AllowedCPUs" systemctl-${jobid}.log
 '
-test_expect_success MULTICORE 'jobid.0: but keeps service running' '
+test_expect_success MULTICORE 'jobid.0: marker still present (job remains)' '
+	test -f ${FLUX_PAM_LOCK_DIR}/uid.42.active
+'
+test_expect_success MULTICORE 'jobid.0: does not stop service' '
 	test_must_fail grep "stop user@42.service" systemctl-${jobid}.log
 '
 test_expect_success MULTICORE 'jobid.1: cancel second job' '
@@ -181,6 +191,13 @@ test_expect_success MULTICORE 'jobid.1: cancel second job' '
 test_expect_success MULTICORE 'jobid.1: housekeeping stops user service' '
 	jobid=$(cat jobid.1) &&
 	test_wait_until "grep \"stop user@42.service\" systemctl-${jobid}.log"
+'
+test_expect_success MULTICORE 'jobid.1: marker removed (last job)' '
+	test_must_fail test -f ${FLUX_PAM_LOCK_DIR}/uid.42.active
+'
+test_expect_success MULTICORE 'jobid.1: housekeeping reverted slice constraints' '
+	jobid=$(cat jobid.1) &&
+	grep "revert user-42.slice" systemctl-${jobid}.log
 '
 # MULTICORE-only tests end
 
@@ -208,6 +225,9 @@ test_expect_success 'submit job with kill-user-slice enabled' '
 	flux job wait-event $jobid start &&
 	echo $jobid > jobid.kill
 '
+test_expect_success 'marker present after prolog' '
+	test -f ${FLUX_PAM_LOCK_DIR}/uid.42.active
+'
 test_expect_success 'cancel job and verify kill sequence runs' '
 	jobid=$(cat jobid.kill) &&
 	flux cancel $jobid &&
@@ -215,6 +235,13 @@ test_expect_success 'cancel job and verify kill sequence runs' '
 	test_wait_until \
 		"grep \"stop user@42.service\" systemctl-${jobid}.log" &&
 	test_debug "cat systemctl-${jobid}.log"
+'
+test_expect_success 'marker removed after last job housekeeping' '
+	test_must_fail test -f ${FLUX_PAM_LOCK_DIR}/uid.42.active
+'
+test_expect_success 'housekeeping reverted slice constraints' '
+	jobid=$(cat jobid.kill) &&
+	grep "revert user-42.slice" systemctl-${jobid}.log
 '
 test_expect_success 'housekeeping checks for orphans before killing' '
 	jobid=$(cat jobid.kill) &&
@@ -247,23 +274,25 @@ test_expect_success 'verify default grace time is used' '
 	jobid=$(submit_as_guest 5m --requires="rank:0" sleep 300) &&
 	flux job wait-event $jobid start &&
 	echo $jobid > jobid.default &&
+	test -f ${FLUX_PAM_LOCK_DIR}/uid.42.active &&
 	flux cancel $jobid &&
 	flux job wait-event $jobid clean &&
-	test_wait_until "grep \"stop user@42.service\" systemctl-${jobid}.log"
+	test_wait_until "grep \"stop user@42.service\" systemctl-${jobid}.log" &&
+	test_must_fail test -f ${FLUX_PAM_LOCK_DIR}/uid.42.active
 '
 
 test_expect_success 'configure mock-systemctl to fail on set-property' '
 	broker_setenv MOCK_SYSTEMCTL_FAIL set-property
 '
-test_expect_success 'prolog fails without rolling back service start' '
+test_expect_success 'prolog fails before service start' '
 	jobid=$(submit_as_guest 5m --requires="rank:0" sleep 300) &&
 	echo $jobid > jobid.no-rollback &&
 	# Job should fail during prolog (set-property fails)
 	test_expect_code 1 flux job wait-event -t 10s $jobid start &&
-	test_debug "cat systemctl-${jobid}.log" &&
-	# Service should have been started but NOT stopped
-	grep "start user@42.service" systemctl-${jobid}.log &&
-	test_must_fail grep "stop user@42.service" systemctl-${jobid}.log
+	# Prolog fails before reaching service start, so marker not created
+	test_must_fail test -f ${FLUX_PAM_LOCK_DIR}/uid.42.active &&
+	# No systemctl log created since prolog failed before any systemctl calls
+	test_must_fail test -f systemctl-${jobid}.log
 '
 test_expect_success 'housekeeping cleans up after prolog failure' '
 	jobid=$(cat jobid.no-rollback) &&
@@ -277,6 +306,46 @@ test_expect_success 'restore mock-systemctl for remaining tests' '
 '
 test_expect_success 'undrain all ranks after prolog failure' '
 	flux resource undrain -u 0-3
+'
+
+# Test non-fatal user service start failure (hidepid simulation)
+test_expect_success 'configure mock-systemctl to fail on user service start' '
+	broker_setenv MOCK_SYSTEMCTL_FAIL "start user@"
+'
+test_expect_success 'prolog succeeds despite user service start failure' '
+	jobid=$(submit_as_guest 5m --requires="rank:0" sleep 300) &&
+	flux job wait-event $jobid start &&
+	echo $jobid > jobid.no-service
+'
+test_expect_success 'prolog applied constraints despite service failure' '
+	jobid=$(cat jobid.no-service) &&
+	test_debug "cat systemctl-${jobid}.log" &&
+	grep "set-property --runtime user-42.slice" systemctl-${jobid}.log
+'
+test_expect_success 'marker present despite service start failure' '
+	test -f ${FLUX_PAM_LOCK_DIR}/uid.42.active
+'
+test_expect_success 'service start failure was non-fatal, prolog succeeded' '
+	# The prolog completed successfully despite service start failure,
+	# which is verified by the job reaching start state (test 39)
+	# Just verify the job is running
+	jobid=$(cat jobid.no-service) &&
+	flux job eventlog $jobid | grep "submit"
+'
+test_expect_success 'cancel job with failed service' '
+	jobid=$(cat jobid.no-service) &&
+	flux cancel $jobid &&
+	flux job wait-event $jobid clean
+'
+test_expect_success 'housekeeping tolerates service stop failure' '
+	jobid=$(cat jobid.no-service) &&
+	test_wait_until "grep \"stop user@42.service\" systemctl-${jobid}.log"
+'
+test_expect_success 'marker removed after housekeeping' '
+	test_must_fail test -f ${FLUX_PAM_LOCK_DIR}/uid.42.active
+'
+test_expect_success 'restore mock-systemctl for remaining tests' '
+	broker_unsetenv MOCK_SYSTEMCTL_FAIL
 '
 test_expect_success 'cancel any remaining jobs before concurrent test' '
 	flux cancel --all --user=all &&
@@ -312,6 +381,10 @@ test_expect_success MULTICORE 'submit two jobs concurrently on same rank' '
 	flux job wait-event -vt 20 $jobid1 start &&
 	flux job wait-event -vt 20 $jobid2 start
 '
+test_expect_success MULTICORE 'verify marker created by concurrent prologs' '
+	# Marker should be created once (idempotent under lock)
+	test -f ${FLUX_PAM_LOCK_DIR}/uid.42.active
+'
 test_expect_success MULTICORE 'verify both prologs started the service' '
 	# Both prologs always call start; systemctl start is idempotent
 	jobid1=$(cat jobid.concurrent1) &&
@@ -333,7 +406,12 @@ test_expect_success MULTICORE 'cleanup concurrent test jobs' '
 	flux cancel $(cat jobid.concurrent1) &&
 	flux cancel $(cat jobid.concurrent2) &&
 	flux job wait-event -vt 30 $(cat jobid.concurrent1) clean &&
-	flux job wait-event -vt 30 $(cat jobid.concurrent2) clean
+	flux job wait-event -vt 30 $(cat jobid.concurrent2) clean &&
+	# Wait for housekeeping to complete for both jobs
+	test_wait_until "test_must_fail test -f ${FLUX_PAM_LOCK_DIR}/uid.42.active"
+'
+test_expect_success MULTICORE 'marker removed after last concurrent job' '
+	test_must_fail test -f ${FLUX_PAM_LOCK_DIR}/uid.42.active
 '
 # end MULTICORE tests
 
@@ -347,6 +425,9 @@ test_expect_success 'lock-dir-creation: submit job with no lock dir' '
 '
 test_expect_success 'lock-dir-creation: prolog created lock directory' '
 	test -d ${FLUX_PAM_LOCK_DIR}
+'
+test_expect_success 'lock-dir-creation: marker file present' '
+	test -f ${FLUX_PAM_LOCK_DIR}/uid.42.active
 '
 test_expect_success 'lock-dir-creation: directory has correct permissions (0700)' '
 	perms=$(stat -c "%a" ${FLUX_PAM_LOCK_DIR}) &&

--- a/t/t0003-pam-session-tests.t
+++ b/t/t0003-pam-session-tests.t
@@ -75,6 +75,9 @@ TEST_UID=$(id -u ${TEST_USER})
 # FAKE_USERID required for submit_as_guest()
 FAKE_USERID=${TEST_UID}
 
+# Use test trash directory for lock files (matches PAM stack lock-dir)
+export FLUX_PAM_LOCK_DIR=$(pwd)
+
 # Acquire lock for this user's systemd service
 test_systemd_user_lock ${TEST_UID}
 
@@ -128,12 +131,8 @@ test_expect_success 'get service state for test user' '
 test_expect_success 'slice-state: stop any existing service for test user' '
 	sudo systemctl stop user@${TEST_UID}.service || :
 '
-test_expect_success 'slice-state: verify test service is not running' '
-	test_must_fail sudo systemctl is-active user@${TEST_UID}.service
-'
-test_expect_success 'slice-state: start user@.service for test' '
-	sudo systemctl start user@${TEST_UID}.service &&
-	sudo systemctl is-active user@${TEST_UID}.service
+test_expect_success 'slice-state: remove any existing marker' '
+	sudo rm -f ${FLUX_PAM_LOCK_DIR}/uid.${TEST_UID}.active
 '
 test_expect_success 'slice-state: clean up any scopes from previous tests' '
 	reset_test_scopes
@@ -142,25 +141,28 @@ test_expect_success 'slice-state: submit test job' '
 	jobid=$(submit_as_guest 5m sleep 300) &&
 	flux job wait-event -vt 20 $jobid start
 '
-test_expect_success 'slice-state: session attach succeeds with active service' '
+test_expect_success 'slice-state: manually create marker (prolog not configured)' '
+	sudo touch ${FLUX_PAM_LOCK_DIR}/uid.${TEST_UID}.active &&
+	test -f ${FLUX_PAM_LOCK_DIR}/uid.${TEST_UID}.active
+'
+test_expect_success 'slice-state: session attach succeeds with marker present' '
 	pamtest_session -u ${TEST_USER}
 '
-test_expect_success 'slice-state: stop user@.service' '
-	sudo systemctl stop user@${TEST_UID}.service &&
-	test_must_fail sudo systemctl is-active user@${TEST_UID}.service
+test_expect_success 'slice-state: remove marker to simulate teardown' '
+	sudo rm -f ${FLUX_PAM_LOCK_DIR}/uid.${TEST_UID}.active
 '
-test_expect_success 'slice-state: session attach fails with inactive service' '
+test_expect_success 'slice-state: session attach fails without marker' '
 	test_must_fail pamtest_session -u ${TEST_USER}
 '
 test_expect_success 'slice-state: cancel running job' '
 	flux cancel $jobid &&
 	flux job wait-event -vt 20 $jobid clean
 '
-test_expect_success 'scope-create: start user@.service for test' '
-	sudo systemctl start user@${TEST_UID}.service &&
-	sudo systemctl is-active user@${TEST_UID}.service
+test_expect_success 'scope-create: create marker for test' '
+	sudo mkdir -p ${FLUX_PAM_LOCK_DIR} &&
+	sudo touch ${FLUX_PAM_LOCK_DIR}/uid.${TEST_UID}.active
 '
-test_expect_success 'scope-creat: clean up any scopes from previous tests' '
+test_expect_success 'scope-create: clean up any scopes from previous tests' '
 	reset_test_scopes
 '
 test_expect_success 'scope-create: submit test job' '
@@ -212,9 +214,8 @@ test_expect_success 'lock-dir-perms: submit test job' '
 	jobid=$(submit_as_guest 5m sleep 300) &&
 	flux job wait-event $jobid start
 '
-test_expect_success 'lock-dir-perms: start user service' '
-	sudo systemctl start user@${TEST_UID}.service &&
-	sudo systemctl is-active user@${TEST_UID}.service
+test_expect_success 'lock-dir-perms: create marker' '
+	sudo touch ${FLUX_PAM_LOCK_DIR}/uid.${TEST_UID}.active
 '
 test_expect_success 'lock-dir-perms: session fails with group-writable dir' '
 	test_must_fail \
@@ -252,9 +253,8 @@ test_expect_success 'lock-dir-perms: submit another test job' '
 	jobid=$(submit_as_guest 5m sleep 300) &&
 	flux job wait-event $jobid start
 '
-test_expect_success 'lock-dir-perms: restart user service' '
-	sudo systemctl start user@${TEST_UID}.service &&
-	sudo systemctl is-active user@${TEST_UID}.service
+test_expect_success 'lock-dir-perms: recreate marker' '
+	sudo touch ${FLUX_PAM_LOCK_DIR}/uid.${TEST_UID}.active
 '
 test_expect_success 'lock-dir-perms: session fails with other-writable dir' '
 	test_must_fail \
@@ -307,9 +307,10 @@ test_expect_success 'systemd-user: cancel test job' '
 test_expect_success 'cleanup test scopes' '
 	reset_test_scopes
 '
-test_expect_success 'reset state of test user manager' '
+test_expect_success 'reset state of test user manager and marker' '
 	if test "${SERVICE_STATE}" = "inactive"; then
 		sudo systemctl stop user@${TEST_UID}.service
-	fi
+	fi &&
+	sudo rm -f ${FLUX_PAM_LOCK_DIR}/uid.${TEST_UID}.active
 '
 test_done


### PR DESCRIPTION
flux-pam currently uses the systemd user@UID service as the control method for activating the user slice as well as a gate for the PAM session module to ensure that slice constraints are being managed by flux-pam prolog and housekeeping. However, as described in #25, it is not guaranteed that the user manager can even reliably be started on compute nodes.

Since the reality is that flux-pam really only needs to manage the user slice, and availability of the user@UID service is just a nice-to-have, this PR switches flux-pam to simply managing the user slice properties (if `exec.sdexec-constrain-resources` is set), and to use a per-user marker (presence of a file in `/run/flux-pam`) for the session module to determine that the user slice is indeed being actively managed and a scope for the user login can be created there.

The prolog now attempts to start the user@UID service after the slice is prepared, but failure is non-fatal.

This approach actually simplifies the prolog/housekeeping and PAM session module somewhat, so overall seems like a better approach anyway.

Because this is largely a rewrite of the implementation, there is one big commit with all the code and test changes. Anything else would have resulted in breaking changes along the way. Apologies for that.

The documentation is also updated, and now includes a section on issues with `/proc` and `hidepid=2` that were the precipitating cause of these changes, so that users and admins have some clue why the user manager may not start on compute nodes when flux-pam claims to start it.

Fixes #25