### PR TITLE
NEWS.md: add release notes for v0.4.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+flux-pam version 0.4.0 - 2026-06-08
+-----------------------------------
+
+ * doc: add introduction to documentation index (#24)
+ * pam: fix `pam_flux.so` interaction with systemd-user PAM service (#23)
+ * switch to marker-based slice containment instead of managing user@UID
+   service (#26)
+
 flux-pam version 0.3.0 - 2026-06-04
 -----------------------------------
 


### PR DESCRIPTION
Problem: There are no release notes for flux-pam v0.4.0.

Add them.

This assumes #26 will be merged.