### PR TITLE
build: add LICENSE to tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,7 @@
 ACLOCAL_AMFLAGS = -I config
 
 EXTRA_DIST = \
+	LICENSE \
 	NEWS.md \
 	README.md \
 	NOTICE.LLNS \


### PR DESCRIPTION
Problem: the LICENSE file is not currently included in release tarballs

Add it by listing it in EXTRA_DIST in the top-level Makefile.am